### PR TITLE
Implement Groq API retry logic

### DIFF
--- a/src/groq_client.py
+++ b/src/groq_client.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+import time
 import requests
+from requests.exceptions import HTTPError, RequestException
 
 from config import settings
 
@@ -11,10 +13,46 @@ GROQ_API_URL = "https://api.groq.com/v1/completions"
 PROMPT_TEMPLATE = "Review the following text for grammar and style:\n\n{text}"
 
 
-def get_suggestions(text: str, prompt_template: str = PROMPT_TEMPLATE) -> Dict[str, Any]:
-    """Send ``text`` to Groq API and return the JSON response."""
+def get_suggestions(
+    text: str,
+    prompt_template: str = PROMPT_TEMPLATE,
+    *,
+    retries: int = 3,
+    backoff: float = 1.0,
+) -> Dict[str, Any]:
+    """Send ``text`` to Groq API and return the JSON response.
+
+    Parameters
+    ----------
+    text:
+        The text to review.
+    prompt_template:
+        Template used to build the prompt sent to Groq.
+    retries:
+        Number of times to retry on errors.
+    backoff:
+        Seconds to wait between retries; doubles after each attempt.
+    """
     headers = {"Authorization": f"Bearer {settings.GROQ_API_KEY}"}
     payload = {"prompt": prompt_template.format(text=text)}
-    response = requests.post(GROQ_API_URL, json=payload, headers=headers, timeout=30)
-    response.raise_for_status()
-    return response.json()
+
+    for attempt in range(1, retries + 1):
+        try:
+            response = requests.post(
+                GROQ_API_URL, json=payload, headers=headers, timeout=30
+            )
+            response.raise_for_status()
+            return response.json()
+        except HTTPError as exc:  # Retry on 5xx responses
+            status = exc.response.status_code if exc.response else None
+            if status and 500 <= status < 600 and attempt < retries:
+                time.sleep(backoff)
+                backoff *= 2
+            else:
+                raise
+        except RequestException:
+            if attempt < retries:
+                time.sleep(backoff)
+                backoff *= 2
+            else:
+                raise

--- a/test/test_groq_client.py
+++ b/test/test_groq_client.py
@@ -1,4 +1,6 @@
-from src.groq_client import get_suggestions, GROQ_API_URL
+import pytest
+
+from src.groq_client import GROQ_API_URL, get_suggestions
 
 
 def test_get_suggestions_calls_api(monkeypatch):
@@ -25,3 +27,44 @@ def test_get_suggestions_calls_api(monkeypatch):
     assert captured["url"] == GROQ_API_URL
     assert "Authorization" in captured["headers"]
     assert "Some text" in captured["json"]["prompt"]
+
+
+def test_get_suggestions_retries_on_server_error(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_post(url, json, headers, timeout):
+        calls["count"] += 1
+
+        class Resp:
+            def __init__(self, ok):
+                self.ok = ok
+                self.status_code = 500 if not ok else 200
+
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    from requests import HTTPError
+
+                    raise HTTPError(response=self)
+
+            def json(self):
+                return {"choices": []}
+
+        if calls["count"] == 1:
+            return Resp(False)
+        return Resp(True)
+
+    monkeypatch.setattr("requests.post", fake_post)
+    resp = get_suggestions("ok")
+    assert resp == {"choices": []}
+    assert calls["count"] == 2
+
+
+def test_get_suggestions_raises_after_retries(monkeypatch):
+    def fake_post(url, json, headers, timeout):
+        from requests import RequestException
+
+        raise RequestException("boom")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    with pytest.raises(Exception):
+        get_suggestions("fail", retries=2, backoff=0)


### PR DESCRIPTION
## Summary
- add retry with exponential backoff to Groq client
- exercise new error-handling behavior in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d3b20d6208328ace03ec6588affc7