### PR TITLE
Integrate revision tracking and review pipeline

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -9,7 +9,7 @@ from googleapiclient.discovery import build
 
 from config import settings
 
-SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
+SCOPES = ["https://www.googleapis.com/auth/drive"]
 
 
 def build_drive_service() -> Any:
@@ -40,3 +40,34 @@ def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]
         .execute()
     )
     return results.get("files", [])
+
+
+def get_app_properties(service: Any, file_id: str) -> tuple[Dict[str, str], str]:
+    """Return ``appProperties`` and ``headRevisionId`` for ``file_id``."""
+    result = (
+        service.files()
+        .get(fileId=file_id, fields="appProperties, headRevisionId")
+        .execute()
+    )
+    return result.get("appProperties", {}), result.get("headRevisionId", "")
+
+
+def update_app_properties(
+    service: Any, file_id: str, app_properties: Dict[str, str]
+) -> None:
+    """Update ``appProperties`` for ``file_id``."""
+    service.files().update(
+        fileId=file_id, body={"appProperties": app_properties}
+    ).execute()
+
+
+def download_revision_text(service: Any, file_id: str, revision_id: str) -> str:
+    """Download revision content as plain text."""
+    content = (
+        service.revisions()
+        .get(fileId=file_id, revisionId=revision_id, alt="media")
+        .execute()
+    )
+    if isinstance(content, bytes):
+        return content.decode()
+    return content

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -1,7 +1,12 @@
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
-from src.google_drive import list_recent_docs
+from src.google_drive import (
+    download_revision_text,
+    get_app_properties,
+    list_recent_docs,
+    update_app_properties,
+)
 
 
 def test_list_recent_docs_filters_by_time():
@@ -15,3 +20,26 @@ def test_list_recent_docs_filters_by_time():
     files = list_recent_docs(service, since)
     service.files.assert_called_once()
     assert files[0]["name"] == "Doc1"
+
+
+def test_app_properties_roundtrip():
+    service = MagicMock()
+    service.files.return_value.get.return_value.execute.return_value = {
+        "appProperties": {"x": "1"},
+        "headRevisionId": "5",
+    }
+    props, rev = get_app_properties(service, "file")
+    assert props == {"x": "1"}
+    assert rev == "5"
+
+    update_app_properties(service, "file", props)
+    service.files.return_value.update.assert_called_once_with(
+        fileId="file", body={"appProperties": props}
+    )
+
+
+def test_download_revision_text_decodes_bytes():
+    service = MagicMock()
+    service.revisions.return_value.get.return_value.execute.return_value = b"hello"
+    text = download_revision_text(service, "f", "1")
+    assert text == "hello"

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -1,4 +1,11 @@
-from src.review import detect_changed_ranges, deduplicate_suggestions
+from unittest.mock import MagicMock
+
+from src.review import (
+    _hash,
+    deduplicate_suggestions,
+    detect_changed_ranges,
+    review_document,
+)
 
 
 def test_detect_changed_ranges():
@@ -24,3 +31,43 @@ def test_deduplicate_suggestions():
         [{"suggestion": "Fix typo", "quote": "teh"}], existing
     )
     assert again == []
+
+
+def test_review_document_pipeline():
+    drive = MagicMock()
+    drive.files.return_value.get.return_value.execute.return_value = {
+        "appProperties": {"lastReviewedRevisionId": "1", "suggestionHashes": "abcd"},
+        "headRevisionId": "2",
+    }
+    drive.revisions.return_value.get.return_value.execute.return_value = (
+        "para1\npara2\n"
+    )
+
+    docs = MagicMock()
+    docs.documents.return_value.get.return_value.execute.return_value = {
+        "body": {
+            "content": [
+                {"paragraph": {"elements": [{"textRun": {"content": "para1"}}]}},
+                {
+                    "paragraph": {
+                        "elements": [
+                            {"textRun": {"content": "para2 updated"}}
+                        ]
+                    }
+                },
+            ]
+        }
+    }
+
+    def suggest(_text: str):
+        return {"issue": "typo", "suggestion": "Fix typo", "severity": "major"}
+
+    items = review_document(drive, docs, "doc1", suggest)
+    assert len(items) == 1
+    assert items[0]["suggestion"] == "Fix typo"
+
+    expected_hash = _hash("Fix typo", "para2 updated")
+    update_body = drive.files.return_value.update.call_args.kwargs["body"]
+    assert update_body["appProperties"]["lastReviewedRevisionId"] == "2"
+    assert expected_hash in update_body["appProperties"]["suggestionHashes"]
+    assert "abcd" in update_body["appProperties"]["suggestionHashes"]


### PR DESCRIPTION
## Summary
- Add Drive helpers to read/write appProperties and fetch revision text
- Implement end-to-end document review pipeline with revision tracking, Groq suggestions and deduplication
- Extend tests for Drive helpers and full review flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d475826848328a553a8889e91c90a