### PR TITLE
feat: support comment posting and context for reviews

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -71,3 +71,39 @@ def download_revision_text(service: Any, file_id: str, revision_id: str) -> str:
     if isinstance(content, bytes):
         return content.decode()
     return content
+
+
+def get_share_message(service: Any, file_id: str) -> str:
+    """Return the file's description to use as share message context."""
+    result = (
+        service.files()
+        .get(fileId=file_id, fields="description")
+        .execute()
+    )
+    return result.get("description", "")
+
+
+def create_comment(
+    service: Any,
+    file_id: str,
+    content: str,
+    start_index: int | None = None,
+    end_index: int | None = None,
+) -> Any:
+    """Create a comment on ``file_id`` anchored to the given range."""
+    body: Dict[str, Any] = {"content": content}
+    if start_index is not None and end_index is not None:
+        body["anchor"] = f"{start_index},{end_index}"
+    return service.comments().create(fileId=file_id, body=body).execute()
+
+
+def reply_to_comment(
+    service: Any, file_id: str, comment_id: str, content: str
+) -> Any:
+    """Reply to an existing comment thread."""
+    body = {"content": content}
+    return (
+        service.replies()
+        .create(fileId=file_id, commentId=comment_id, body=body)
+        .execute()
+    )

--- a/src/review.py
+++ b/src/review.py
@@ -6,8 +6,10 @@ from difflib import SequenceMatcher
 
 from .google_docs import get_document_paragraphs
 from .google_drive import (
+    create_comment,
     download_revision_text,
     get_app_properties,
+    get_share_message,
     update_app_properties,
 )
 
@@ -51,13 +53,14 @@ def detect_changed_ranges(
 def process_changed_ranges(
     paragraphs: List[str],
     changed_ranges: List[Tuple[int, int]],
-    suggest_fn: Callable[[str], Dict[str, Any]],
+    suggest_fn: Callable[[str, str], Dict[str, Any]],
+    context: str = "",
 ) -> List[Dict[str, str]]:
     """Run ``suggest_fn`` on changed text ranges and format results."""
     items: List[Dict[str, str]] = []
     for start, end in changed_ranges:
         text = "".join(paragraphs[start : end + 1])
-        response = suggest_fn(text)
+        response = suggest_fn(text, context)
         items.append(
             {
                 "issue": response.get("issue", ""),
@@ -93,11 +96,12 @@ def review_document(
     drive_service: Any,
     docs_service: Any,
     document_id: str,
-    suggest_fn: Callable[[str], Dict[str, Any]],
+    suggest_fn: Callable[[str, str], Dict[str, Any]],
 ) -> List[Dict[str, str]]:
     """End-to-end review pipeline for a single document."""
     app_properties, head_revision = get_app_properties(drive_service, document_id)
     last_revision = get_last_reviewed_revision(app_properties)
+    context = get_share_message(drive_service, document_id)
 
     current_paragraphs = get_document_paragraphs(docs_service, document_id)
     old_paragraphs: List[str] = []
@@ -106,7 +110,9 @@ def review_document(
         old_paragraphs = old_text.splitlines()
 
     changed = detect_changed_ranges(old_paragraphs, current_paragraphs)
-    items = process_changed_ranges(current_paragraphs, changed, suggest_fn)
+    items = process_changed_ranges(
+        current_paragraphs, changed, suggest_fn, context=context
+    )
 
     existing_hashes = set()
     if app_properties.get("suggestionHashes"):
@@ -118,3 +124,9 @@ def review_document(
     update_app_properties(drive_service, document_id, app_properties)
 
     return unique
+
+
+def post_comments(drive_service: Any, document_id: str, items: List[Dict[str, str]]) -> None:
+    """Post review items as comments on the document."""
+    for item in items:
+        create_comment(drive_service, document_id, item["suggestion"])

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -3,8 +3,11 @@ from unittest.mock import MagicMock
 
 from src.google_drive import (
     download_revision_text,
+    create_comment,
+    get_share_message,
     get_app_properties,
     list_recent_docs,
+    reply_to_comment,
     update_app_properties,
 )
 
@@ -43,3 +46,28 @@ def test_download_revision_text_decodes_bytes():
     service.revisions.return_value.get.return_value.execute.return_value = b"hello"
     text = download_revision_text(service, "f", "1")
     assert text == "hello"
+
+
+def test_get_share_message_fetches_description():
+    service = MagicMock()
+    service.files.return_value.get.return_value.execute.return_value = {
+        "description": "context"
+    }
+    msg = get_share_message(service, "file")
+    assert msg == "context"
+    service.files.return_value.get.assert_called_once_with(
+        fileId="file", fields="description"
+    )
+
+
+def test_create_and_reply_comment():
+    service = MagicMock()
+    create_comment(service, "file", "hello", 1, 5)
+    service.comments.return_value.create.assert_called_once_with(
+        fileId="file", body={"content": "hello", "anchor": "1,5"}
+    )
+
+    reply_to_comment(service, "file", "c1", "thanks")
+    service.replies.return_value.create.assert_called_once_with(
+        fileId="file", commentId="c1", body={"content": "thanks"}
+    )

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -4,6 +4,7 @@ from src.review import (
     _hash,
     deduplicate_suggestions,
     detect_changed_ranges,
+    post_comments,
     review_document,
 )
 
@@ -35,10 +36,25 @@ def test_deduplicate_suggestions():
 
 def test_review_document_pipeline():
     drive = MagicMock()
-    drive.files.return_value.get.return_value.execute.return_value = {
-        "appProperties": {"lastReviewedRevisionId": "1", "suggestionHashes": "abcd"},
-        "headRevisionId": "2",
-    }
+
+    def files_get(fileId=None, fields=None):
+        if fields == "appProperties, headRevisionId":
+            return MagicMock(
+                execute=MagicMock(
+                    return_value={
+                        "appProperties": {
+                            "lastReviewedRevisionId": "1",
+                            "suggestionHashes": "abcd",
+                        },
+                        "headRevisionId": "2",
+                    }
+                )
+            )
+        if fields == "description":
+            return MagicMock(execute=MagicMock(return_value={"description": "share msg"}))
+        return MagicMock(execute=MagicMock(return_value={}))
+
+    drive.files.return_value.get.side_effect = files_get
     drive.revisions.return_value.get.return_value.execute.return_value = (
         "para1\npara2\n"
     )
@@ -59,15 +75,31 @@ def test_review_document_pipeline():
         }
     }
 
-    def suggest(_text: str):
+    captured = {}
+
+    def suggest(_text: str, context: str):
+        captured["context"] = context
         return {"issue": "typo", "suggestion": "Fix typo", "severity": "major"}
 
     items = review_document(drive, docs, "doc1", suggest)
     assert len(items) == 1
     assert items[0]["suggestion"] == "Fix typo"
+    assert captured["context"] == "share msg"
 
     expected_hash = _hash("Fix typo", "para2 updated")
     update_body = drive.files.return_value.update.call_args.kwargs["body"]
     assert update_body["appProperties"]["lastReviewedRevisionId"] == "2"
     assert expected_hash in update_body["appProperties"]["suggestionHashes"]
     assert "abcd" in update_body["appProperties"]["suggestionHashes"]
+
+
+def test_post_comments_calls_create(monkeypatch):
+    calls = []
+
+    def fake_create(service, file_id, content, start_index=None, end_index=None):
+        calls.append((file_id, content))
+
+    monkeypatch.setattr("src.review.create_comment", fake_create)
+    items = [{"suggestion": "Fix typo"}]
+    post_comments("svc", "doc1", items)
+    assert calls == [("doc1", "Fix typo")]


### PR DESCRIPTION
## Summary
- add Drive helpers for fetching share messages, posting comments, and replying to threads
- thread context now flows through review pipeline
- provide helper to post review items as comments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4c924c9c8328b4c24b0906cc7b8d