### PR TITLE
Add polling runner and comment anchoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ groq
 python-dotenv
 requests
 pytest
+schedule

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,53 @@
+"""Scheduled runner entry point for ClearMyBoss."""
+from __future__ import annotations
+
+from datetime import datetime
+import time
+from typing import Any
+
+from .google_drive import build_drive_service, list_recent_docs
+from .google_docs import build_docs_service
+from .groq_client import get_suggestions
+from .review import review_document, post_comments
+
+
+def groq_suggest(text: str, context: str) -> dict[str, str]:
+    """Wrapper around :func:`get_suggestions` producing review item dicts."""
+    prompt = f"{context}\n\n{text}" if context else text
+    resp = get_suggestions(prompt)
+    suggestion = ""
+    if resp.get("choices"):
+        choice = resp["choices"][0]
+        suggestion = choice.get("text") or choice.get("message", {}).get("content", "")
+    return {"issue": "", "suggestion": suggestion.strip(), "severity": "info"}
+
+
+def run_once(drive_service: Any, docs_service: Any, since: datetime) -> datetime:
+    """Process documents modified since ``since`` and return new timestamp."""
+    files = list_recent_docs(drive_service, since)
+    for f in files:
+        doc_id = f["id"]
+        items = review_document(drive_service, docs_service, doc_id, groq_suggest)
+        if items:
+            post_comments(drive_service, doc_id, items)
+    return datetime.utcnow()
+
+
+def main() -> None:
+    drive_service = build_drive_service()
+    docs_service = build_docs_service()
+    since = datetime.utcnow()
+    import schedule
+
+    def job() -> None:
+        nonlocal since
+        since = run_once(drive_service, docs_service, since)
+
+    schedule.every(5).minutes.do(job)
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from src.main import run_once
+
+
+def test_run_once_reviews_and_posts(monkeypatch):
+    drive = MagicMock()
+    docs = MagicMock()
+
+    monkeypatch.setattr(
+        "src.main.list_recent_docs", lambda svc, since: [{"id": "1"}, {"id": "2"}]
+    )
+
+    reviews = [
+        [{"suggestion": "s1", "hash": "h1", "start_index": 0, "end_index": 1}],
+        [],
+    ]
+
+    def fake_review(drive_service, docs_service, doc_id, suggest_fn):
+        return reviews.pop(0)
+
+    monkeypatch.setattr("src.main.review_document", fake_review)
+
+    posted = []
+
+    def fake_post(drive_service, doc_id, items):
+        posted.append((doc_id, items))
+
+    monkeypatch.setattr("src.main.post_comments", fake_post)
+
+    since = datetime.utcnow()
+    new_since = run_once(drive, docs, since)
+
+    assert posted == [(
+        "1",
+        [{"suggestion": "s1", "hash": "h1", "start_index": 0, "end_index": 1}],
+    )]
+    assert isinstance(new_since, datetime) and new_since >= since


### PR DESCRIPTION
## Summary
- compute start and end indices for changed text ranges and prefix comments with an AI reviewer hash
- add a scheduled runner with `run_once` and CLI entry point `main`
- expand tests to cover comment formatting and the polling runner

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d525b5720832880dbe3d8638d02aa