### PR TITLE
Fix Groq API endpoint and Google Drive comment fields

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -94,7 +94,11 @@ def create_comment(
     body: Dict[str, Any] = {"content": content}
     if start_index is not None and end_index is not None:
         body["anchor"] = f"{start_index},{end_index}"
-    return service.comments().create(fileId=file_id, body=body).execute()
+    return (
+        service.comments()
+        .create(fileId=file_id, body=body, fields="id")
+        .execute()
+    )
 
 
 def reply_to_comment(

--- a/src/groq_client.py
+++ b/src/groq_client.py
@@ -9,7 +9,8 @@ from requests.exceptions import HTTPError, RequestException
 
 from config import settings
 
-GROQ_API_URL = "https://api.groq.com/v1/completions"
+# Updated base URL to match Groq's OpenAI-compatible endpoint
+GROQ_API_URL = "https://api.groq.com/openai/v1/completions"
 PROMPT_TEMPLATE = "Review the following text for grammar and style:\n\n{text}"
 
 

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -64,7 +64,7 @@ def test_create_and_reply_comment():
     service = MagicMock()
     create_comment(service, "file", "hello", 1, 5)
     service.comments.return_value.create.assert_called_once_with(
-        fileId="file", body={"content": "hello", "anchor": "1,5"}
+        fileId="file", body={"content": "hello", "anchor": "1,5"}, fields="id"
     )
 
     reply_to_comment(service, "file", "c1", "thanks")


### PR DESCRIPTION
## Summary
- Point Groq client to the correct OpenAI-compatible endpoint
- Supply required `fields` parameter when creating Google Drive comments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5bf51b4883289458411a9676dbb0