### PR TITLE
Fix Groq API payload

### DIFF
--- a/src/groq_client.py
+++ b/src/groq_client.py
@@ -9,7 +9,8 @@ from requests.exceptions import HTTPError, RequestException
 
 from config import settings
 
-GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions"
+# Groq's OpenAI-compatible endpoint for text completions
+GROQ_API_URL = "https://api.groq.com/openai/v1/completions"
 PROMPT_TEMPLATE = "Review the following text for grammar and style:\n\n{text}"
 
 def get_suggestions(
@@ -27,12 +28,9 @@ def get_suggestions(
     prompt = prompt_template.format(text=text)
 
     payload = {
-        # Use a current model:
+        # Use a current model
         "model": "llama-3.1-8b-instant",
-        "messages": [
-            {"role": "system", "content": "You are a document reviewer and editor."},
-            {"role": "user", "content": prompt},
-        ],
+        "prompt": prompt,
         # Keep completions modest; oversized requests can 400 with context errors.
         "temperature": 0.2,
         "max_tokens": 800,

--- a/test/test_groq_client.py
+++ b/test/test_groq_client.py
@@ -13,6 +13,7 @@ def test_get_suggestions_calls_api(monkeypatch):
         captured["timeout"] = timeout
 
         class Resp:
+            status_code = 200
             def raise_for_status(self):
                 pass
 


### PR DESCRIPTION
## Summary
- Use Groq text completions endpoint and pass prompt-based payload
- Adjust Groq client tests for updated response handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d61d4b5b8832891d1f87268958989