### PR TITLE
Chunk Groq requests for large inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # ClearMyBoss
-A MVP that plugs into Google Docs and lets an AI automatically review the document and leave comments (like how your boss would do it),
+A MVP that plugs into Google Docs and lets an AI automatically review the document and leave comments (like how your boss would do it).
+
+## Groq API
+
+`src/groq_client.py` contacts Groq's Chat Completions endpoint for grammar
+feedback. Long documents are automatically split into 8KB chunks before
+being sent to the API to avoid request-size errors. The suggestions from
+each chunk are concatenated into a single response.


### PR DESCRIPTION
## Summary
- Split long documents into 8KB chunks before calling Groq API and concatenate responses
- Document Groq chunking behavior in README
- Add unit test verifying multiple API calls for oversized input

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d666da1088328bb17dd248c24e270