### PR TITLE
Make Groq chunk size configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 GROQ_API_KEY=your_groq_api_key_here
 GOOGLE_SERVICE_ACCOUNT_JSON=path/to/service_account.json
+GROQ_CHUNK_SIZE=104857

--- a/config/settings.py
+++ b/config/settings.py
@@ -6,3 +6,6 @@ load_dotenv()
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
 GROQ_REQUESTS_PER_MINUTE = int(os.getenv("GROQ_REQUESTS_PER_MINUTE", "60"))
+GROQ_CHUNK_SIZE = int(
+    os.getenv("GROQ_CHUNK_SIZE", str(3 * 1024 * 1024 // 30))
+)

--- a/src/groq_client.py
+++ b/src/groq_client.py
@@ -19,7 +19,10 @@ logger = logging.getLogger(__name__)
 # `/chat/completions` route rather than the legacy `/completions` path.
 GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions"
 PROMPT_TEMPLATE = "Review the following text for grammar and style:\n\n{text}"
-CHUNK_SIZE = 8 * 1024  # 8KB, keep requests comfortably under Groq limits
+# Maximum bytes of text per request. Default derives from a 3MB document
+# split across 30 requests (about 100KB). Can be overridden via
+# ``GROQ_CHUNK_SIZE`` environment variable.
+CHUNK_SIZE = settings.GROQ_CHUNK_SIZE
 
 
 class RateLimiter:


### PR DESCRIPTION
## Summary
- make text chunk size for Groq API requests configurable via `GROQ_CHUNK_SIZE` env var
- use new chunk size in Groq client instead of hardcoded 8KB
- document `GROQ_CHUNK_SIZE` in sample environment file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d8b5a3f408328ae76120e6f02dffc