### PR TITLE
Handle missing Google Drive credentials path

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import os
 from typing import List, Dict, Any
 
 from google.oauth2 import service_account
@@ -13,9 +14,28 @@ SCOPES = ["https://www.googleapis.com/auth/drive"]
 
 
 def build_drive_service() -> Any:
-    """Build an authenticated Drive API service using service account credentials."""
+    """Build an authenticated Drive API service using service account credentials.
+
+    Raises
+    ------
+    ValueError
+        If ``GOOGLE_SERVICE_ACCOUNT_JSON`` is not set in the environment.
+    FileNotFoundError
+        If the path specified by ``GOOGLE_SERVICE_ACCOUNT_JSON`` does not exist.
+    """
+
+    cred_path = settings.GOOGLE_SERVICE_ACCOUNT_JSON
+    if not cred_path:
+        raise ValueError(
+            "GOOGLE_SERVICE_ACCOUNT_JSON environment variable is not set."
+        )
+    if not os.path.exists(cred_path):
+        raise FileNotFoundError(
+            f"Service account JSON file not found at {cred_path}"
+        )
+
     creds = service_account.Credentials.from_service_account_file(
-        settings.GOOGLE_SERVICE_ACCOUNT_JSON, scopes=SCOPES
+        cred_path, scopes=SCOPES
     )
     service = build("drive", "v3", credentials=creds)
     return service

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
+import pytest
 
 from src.google_drive import (
     download_revision_text,
@@ -9,6 +10,7 @@ from src.google_drive import (
     list_recent_docs,
     reply_to_comment,
     update_app_properties,
+    build_drive_service,
 )
 
 
@@ -71,3 +73,12 @@ def test_create_and_reply_comment():
     service.replies.return_value.create.assert_called_once_with(
         fileId="file", commentId="c1", body={"content": "thanks"}
     )
+
+
+def test_build_drive_service_missing_credentials(monkeypatch):
+    """Should raise a clear error when credential path is not configured."""
+    monkeypatch.setattr(
+        "src.google_drive.settings.GOOGLE_SERVICE_ACCOUNT_JSON", None
+    )
+    with pytest.raises(ValueError):
+        build_drive_service()


### PR DESCRIPTION
## Summary
- validate GOOGLE_SERVICE_ACCOUNT_JSON before building Drive service
- add test covering missing credential path scenario

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d8cfbbb208328a0dd2d814e506ec6