### PR TITLE
Specify fields in comment replies

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -128,6 +128,6 @@ def reply_to_comment(
     body = {"content": content}
     return (
         service.replies()
-        .create(fileId=file_id, commentId=comment_id, body=body)
+        .create(fileId=file_id, commentId=comment_id, body=body, fields="id")
         .execute()
     )

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -71,7 +71,7 @@ def test_create_and_reply_comment():
 
     reply_to_comment(service, "file", "c1", "thanks")
     service.replies.return_value.create.assert_called_once_with(
-        fileId="file", commentId="c1", body={"content": "thanks"}
+        fileId="file", commentId="c1", body={"content": "thanks"}, fields="id"
     )
 
 


### PR DESCRIPTION
## Summary
- include explicit `fields` parameter when creating comment replies in the Google Drive helper
- update tests for new behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d98a40f5c83288d616f5f23893cf3