### PR TITLE
Use JSON anchors for Drive comments

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import json
 import os
 from typing import List, Dict, Any
 
@@ -113,7 +114,15 @@ def create_comment(
     """Create a comment on ``file_id`` anchored to the given range."""
     body: Dict[str, Any] = {"content": content}
     if start_index is not None and end_index is not None:
-        body["anchor"] = f"{start_index},{end_index}"
+        body["anchor"] = json.dumps(
+            {
+                "r": {
+                    "segmentId": "",
+                    "startIndex": start_index,
+                    "endIndex": end_index,
+                }
+            }
+        )
     return (
         service.comments()
         .create(fileId=file_id, body=body, fields="id")

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
+import json
 import pytest
 
 from src.google_drive import (
@@ -68,8 +69,11 @@ def test_get_share_message_fetches_description():
 def test_create_and_reply_comment():
     service = MagicMock()
     create_comment(service, "file", "hello", 1, 5)
+    expected_anchor = json.dumps(
+        {"r": {"segmentId": "", "startIndex": 1, "endIndex": 5}}
+    )
     service.comments.return_value.create.assert_called_once_with(
-        fileId="file", body={"content": "hello", "anchor": "1,5"}, fields="id"
+        fileId="file", body={"content": "hello", "anchor": expected_anchor}, fields="id"
     )
 
     reply_to_comment(service, "file", "c1", "thanks")


### PR DESCRIPTION
## Summary
- Serialize comment anchor ranges as JSON strings when creating Drive comments
- Adjust unit tests to match new anchor JSON format

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e9372afe083288bcdaf5eaf7fabff