### PR TITLE
Ignore empty suggestions during deduplication

### DIFF
--- a/src/review.py
+++ b/src/review.py
@@ -131,6 +131,8 @@ def deduplicate_suggestions(
     """Remove suggestions already represented by ``existing_hashes``."""
     unique: List[Dict[str, str]] = []
     for item in items:
+        if not item.get("suggestion"):
+            continue
         h = _hash(item["suggestion"], item["quote"])
         if h in existing_hashes:
             continue

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -36,6 +36,19 @@ def test_deduplicate_suggestions():
     assert again == []
 
 
+def test_deduplicate_suggestions_skips_empty():
+    existing = set()
+    items = [
+        {"suggestion": "", "quote": "teh"},
+        {"suggestion": "Fix typo", "quote": "teh"},
+    ]
+    unique = deduplicate_suggestions(items, existing)
+    assert len(unique) == 1
+    assert unique[0]["suggestion"] == "Fix typo"
+    # existing should only contain hash for non-empty suggestion
+    assert len(existing) == 1
+
+
 def test_prune_hashes_limit():
     hashes = [f"{i:08x}" for i in range(30)]
     result = _prune_hashes(hashes)
@@ -120,6 +133,57 @@ def test_review_document_pipeline():
     assert update_body["appProperties"]["lastReviewedRevisionId"] == "2"
     assert expected_hash in update_body["appProperties"]["suggestionHashes"]
     assert "abcd" in update_body["appProperties"]["suggestionHashes"]
+
+
+def test_review_document_ignores_empty_suggestions():
+    drive = MagicMock()
+
+    def files_get(fileId=None, fields=None):
+        if fields == "appProperties, headRevisionId":
+            return MagicMock(
+                execute=MagicMock(
+                    return_value={
+                        "appProperties": {
+                            "lastReviewedRevisionId": "1",
+                            "suggestionHashes": "abcd",
+                        },
+                        "headRevisionId": "2",
+                    }
+                )
+            )
+        if fields == "description":
+            return MagicMock(execute=MagicMock(return_value={"description": "share msg"}))
+        return MagicMock(execute=MagicMock(return_value={}))
+
+    drive.files.return_value.get.side_effect = files_get
+    drive.revisions.return_value.get.return_value.execute.return_value = (
+        "para1\npara2\n"
+    )
+
+    docs = MagicMock()
+    docs.documents.return_value.get.return_value.execute.return_value = {
+        "body": {
+            "content": [
+                {"paragraph": {"elements": [{"textRun": {"content": "para1"}}]}},
+                {
+                    "paragraph": {
+                        "elements": [
+                            {"textRun": {"content": "para2 updated"}}
+                        ]
+                    }
+                },
+            ]
+        }
+    }
+
+    def suggest(_text: str, _context: str):
+        return {"issue": "typo", "suggestion": "", "severity": "major"}
+
+    items = review_document(drive, docs, "doc1", suggest)
+    assert items == []
+    update_body = drive.files.return_value.update.call_args.kwargs["body"]
+    # suggestionHashes should remain unchanged
+    assert update_body["appProperties"]["suggestionHashes"] == "abcd"
 
 
 def test_post_comments_calls_create(monkeypatch):


### PR DESCRIPTION
## Summary
- Skip items with empty `suggestion` when deduplicating to avoid hash creation and property updates
- Test that deduplication ignores empty suggestions and that review_document doesn't update `suggestionHashes`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ea958658083289a91b0e254c6e7c2