### PR TITLE
Fix RateLimiter spacing logic

### DIFF
--- a/src/groq_client.py
+++ b/src/groq_client.py
@@ -69,7 +69,15 @@ class RateLimiter:
                     self.calls.append(now)
                     return
 
-                wait_window = self.calls[0] + 60 - now if self.calls else 0
+                # Only apply the 60-second sliding window wait if we've already
+                # reached the maximum number of calls for the window. When below
+                # the limit we only need to enforce the minimum spacing between
+                # consecutive calls.
+                wait_window = (
+                    self.calls[0] + 60 - now
+                    if len(self.calls) >= self.max_calls
+                    else 0
+                )
                 wait_spacing = (
                     self.calls[-1] + min_interval - now if self.calls else 0
                 )


### PR DESCRIPTION
## Summary
- avoid unnecessary 60-second waits in RateLimiter when below limit

## Testing
- `pytest test/test_groq_client.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ec318f99c832895816799dc00e6ad