### PR TITLE
Support quoted text in Drive comments

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -110,8 +110,25 @@ def create_comment(
     content: str,
     start_index: int | None = None,
     end_index: int | None = None,
+    quoted_text: str | None = None,
 ) -> Any:
-    """Create a comment on ``file_id`` anchored to the given range."""
+    """Create a comment on ``file_id`` anchored to the given range.
+
+    Parameters
+    ----------
+    service
+        Authenticated Google Drive service instance.
+    file_id
+        ID of the document to comment on.
+    content
+        Text content of the comment.
+    start_index, end_index
+        Optional character offsets to anchor the comment.
+    quoted_text
+        Optional text snippet to attach as ``quotedFileContent`` so the comment
+        highlights the exact text.
+    """
+
     body: Dict[str, Any] = {"content": content}
     if start_index is not None and end_index is not None:
         body["anchor"] = json.dumps(
@@ -123,6 +140,8 @@ def create_comment(
                 }
             }
         )
+    if quoted_text is not None:
+        body["quotedFileContent"] = {"mimeType": "text/plain", "value": quoted_text}
     return (
         service.comments()
         .create(fileId=file_id, body=body, fields="id")

--- a/src/review.py
+++ b/src/review.py
@@ -228,6 +228,7 @@ def post_comments(drive_service: Any, document_id: str, items: List[Dict[str, st
             parts[0],
             item.get("start_index"),
             item.get("end_index"),
+            item.get("quote"),
         )
         # Post remaining parts as replies
         for part in parts[1:]:

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -68,12 +68,18 @@ def test_get_share_message_fetches_description():
 
 def test_create_and_reply_comment():
     service = MagicMock()
-    create_comment(service, "file", "hello", 1, 5)
+    create_comment(service, "file", "hello", 1, 5, "teh")
     expected_anchor = json.dumps(
         {"r": {"segmentId": "", "startIndex": 1, "endIndex": 5}}
     )
     service.comments.return_value.create.assert_called_once_with(
-        fileId="file", body={"content": "hello", "anchor": expected_anchor}, fields="id"
+        fileId="file",
+        body={
+            "content": "hello",
+            "anchor": expected_anchor,
+            "quotedFileContent": {"mimeType": "text/plain", "value": "teh"},
+        },
+        fields="id",
     )
 
     reply_to_comment(service, "file", "c1", "thanks")

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -191,8 +191,15 @@ def test_post_comments_calls_create(monkeypatch):
     create_calls = []
     reply_calls = []
 
-    def fake_create(service, file_id, content, start_index=None, end_index=None):
-        create_calls.append((file_id, content, start_index, end_index))
+    def fake_create(
+        service,
+        file_id,
+        content,
+        start_index=None,
+        end_index=None,
+        quoted_text=None,
+    ):
+        create_calls.append((file_id, content, start_index, end_index, quoted_text))
         return {"id": "c1"}
 
     def fake_reply(service, file_id, comment_id, content):
@@ -211,7 +218,7 @@ def test_post_comments_calls_create(monkeypatch):
     ]
     post_comments("svc", "doc1", items)
     assert create_calls == [
-        ("doc1", "AI Reviewer: abcd\nFix typo", 1, 3)
+        ("doc1", "AI Reviewer: abcd\nFix typo", 1, 3, "teh")
     ]
     assert reply_calls == []
 
@@ -220,8 +227,15 @@ def test_post_comments_splits_long_comments(monkeypatch):
     create_calls = []
     reply_calls = []
 
-    def fake_create(service, file_id, content, start_index=None, end_index=None):
-        create_calls.append((file_id, content, start_index, end_index))
+    def fake_create(
+        service,
+        file_id,
+        content,
+        start_index=None,
+        end_index=None,
+        quoted_text=None,
+    ):
+        create_calls.append((file_id, content, start_index, end_index, quoted_text))
         return {"id": "c1"}
 
     def fake_reply(service, file_id, comment_id, content):
@@ -245,6 +259,7 @@ def test_post_comments_splits_long_comments(monkeypatch):
     # First chunk is posted as the main comment, remaining as replies
     assert len(create_calls) == 1
     assert len(reply_calls) == 1
+    assert create_calls[0][4] == "snippet"
     # Ensure the created comment respects size limit
     assert len(create_calls[0][1].encode("utf-8")) <= 4096
     assert len(reply_calls[0][2].encode("utf-8")) <= 4096


### PR DESCRIPTION
## Summary
- allow `create_comment` to attach `quotedFileContent` when a text snippet is provided
- forward `quote` from review items so Drive comments highlight the exact text
- extend tests for quoted text and comment anchoring

## Testing
- `pytest -q`
- `python - <<'PY'
from src.google_drive import build_drive_service, create_comment
try:
    svc = build_drive_service()
    print('Built service', svc)
except Exception as e:
    print('error building service:', e)
PY` *(fails: GOOGLE_SERVICE_ACCOUNT_JSON environment variable is not set.)*

------
https://chatgpt.com/codex/tasks/task_e_689ecfeddff883289503e22ad31db26f