### PR TITLE
Allow broader feedback from Groq

### DIFF
--- a/src/groq_client.py
+++ b/src/groq_client.py
@@ -1,4 +1,4 @@
-"""Simple Groq API client for grammar suggestions."""
+"""Simple Groq API client for text review suggestions."""
 from __future__ import annotations
 
 from typing import Any, Dict, Iterable
@@ -21,14 +21,15 @@ logger = logging.getLogger(__name__)
 GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions"
 # Prompt sent with each request
 PROMPT_TEMPLATE = (
-    "Review the following text for grammar and style. "
+    "Review the following text and provide suggestions for improvement. "
+    "Feel free to ask clarifying questions or offer broader comments beyond grammar. "
     "Respond in one or two short sentences in plain language.\n\n{text}"
 )
 # System instruction to keep the model's feedback brief and relevant
 SYSTEM_PROMPT = (
     "You are a no-nonsense boss reviewing your employee's work. "
-    "Provide direct, actionable feedback in casual, plain language. "
-    "Keep feedback to one or two short sentences."
+    "Provide direct, actionable feedback or clarifying questions in casual, plain language. "
+    "You may comment on broader issues beyond grammar. Keep feedback to one or two short sentences."
 )
 # Maximum bytes of text per request. Default tested at 20KB. Can be overridden via
 # ``GROQ_CHUNK_SIZE`` environment variable.

--- a/src/main.py
+++ b/src/main.py
@@ -23,7 +23,11 @@ logger = logging.getLogger(__name__)
 
 
 def groq_suggest(text: str, context: str) -> dict[str, str]:
-    """Wrapper around :func:`get_suggestions` producing review item dicts."""
+    """Wrapper around :func:`get_suggestions` producing review item dicts.
+
+    The underlying model may return clarifying questions or broader comments in
+    addition to grammar and style feedback.
+    """
     logger.debug(f"Getting suggestions for text length: {len(text)}, context length: {len(context) if context else 0}")
     prompt = f"{context}\n\n{text}" if context else text
     try:

--- a/test/test_groq_client.py
+++ b/test/test_groq_client.py
@@ -31,7 +31,9 @@ def test_get_suggestions_calls_api(monkeypatch):
     msgs = captured["json"]["messages"]
     assert msgs[0]["role"] == "system"
     assert "boss" in msgs[0]["content"].lower()
-    assert msgs[1]["content"].startswith("Review the following")
+    assert "clarifying" in msgs[0]["content"].lower() or "broader" in msgs[0]["content"].lower()
+    assert msgs[1]["content"].lower().startswith("review the following text")
+    assert "clarifying questions" in msgs[1]["content"].lower()
 
 
 def test_get_suggestions_retries_on_server_error(monkeypatch):


### PR DESCRIPTION
## Summary
- Expand Groq system and user prompts to permit clarifying questions and broader comments
- Document new behavior in `groq_suggest`
- Update tests to match expanded prompts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed424c82483288316b9d5a9751d63