### PR TITLE
Handle newly shared Drive documents

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -43,21 +43,28 @@ def build_drive_service() -> Any:
 
 
 def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]:
-    """Return a list of Google Docs modified after ``since_time``.
+    """Return Google Docs modified or shared after ``since_time``.
 
     Parameters
     ----------
-    service: Authenticated Google Drive service instance.
-    since_time: datetime object representing last run time.
+    service
+        Authenticated Google Drive service instance.
+    since_time
+        ``datetime`` of the last run. Documents with ``modifiedTime`` or
+        ``sharedWithMeTime`` after this timestamp are returned.
     """
+
     iso_time = since_time.isoformat("T") + "Z"
     query = (
         "mimeType='application/vnd.google-apps.document' "
-        f"and modifiedTime > '{iso_time}'"
+        f"and (modifiedTime > '{iso_time}' or sharedWithMeTime > '{iso_time}')"
     )
     results = (
         service.files()
-        .list(q=query, fields="files(id, name, modifiedTime)")
+        .list(
+            q=query,
+            fields="files(id, name, modifiedTime, sharedWithMeTime)",
+        )
         .execute()
     )
     return results.get("files", [])


### PR DESCRIPTION
## Summary
- Track files shared via Google Drive's `sharedWithMeTime` to review docs that weren't modified
- Carry forward the latest change timestamp in `run_once` to catch newly shared files
- Test retrieving docs that are only newly shared

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed41e16e083288f53f4518427015e