### PR TITLE
Fix Drive query and uninitialized files list

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -56,6 +56,7 @@ def run_once(drive_service: Any, docs_service: Any, since: datetime) -> datetime
         "Starting document review cycle. Checking for documents changed since: %s", since
     )
 
+    files: list[dict[str, Any]] = []
     try:
         files = list_recent_docs(drive_service, since)
         logger.info("Found %d documents to process", len(files))

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -25,7 +25,7 @@ def test_list_recent_docs_filters_by_time():
             {"id": "1", "name": "Doc1", "modifiedTime": "2024-01-01T00:00:00Z"}
         ]
     }
-    since = datetime.utcnow() - timedelta(days=1)
+    since = datetime(2023, 12, 31, 23, 0, 0)
     files = list_recent_docs(service, since)
     service.files.assert_called_once()
     assert files[0]["name"] == "Doc1"
@@ -49,7 +49,7 @@ def test_list_recent_docs_includes_newly_shared_docs():
     iso_time = since.isoformat("T") + "Z"
     expected_query = (
         "mimeType='application/vnd.google-apps.document' "
-        f"and (modifiedTime > '{iso_time}' or sharedWithMeTime > '{iso_time}')"
+        f"and (modifiedTime > '{iso_time}' or sharedWithMe = true)"
     )
     service.files.return_value.list.assert_called_once_with(
         q=expected_query,


### PR DESCRIPTION
## Summary
- handle Google Drive 'sharedWithMeTime' by querying with `sharedWithMe = true` and filtering results locally
- avoid UnboundLocalError in `run_once` by initializing the files list
- update tests for new Drive query behaviour

## Testing
- `python -m pytest test/test_google_drive.py::test_list_recent_docs_filters_by_time -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed5a3a48c8328b2acfaf4bc525dbb