### PR TITLE
feat: include shared drive docs

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -68,6 +68,9 @@ def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]
         .list(
             q=query,
             fields="files(id, name, modifiedTime, sharedWithMeTime)",
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+            corpora="allDrives",
         )
         .execute()
     )

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -27,7 +27,18 @@ def test_list_recent_docs_filters_by_time():
     }
     since = datetime(2023, 12, 31, 23, 0, 0)
     files = list_recent_docs(service, since)
-    service.files.assert_called_once()
+    iso_time = since.replace(microsecond=0).isoformat("T") + "Z"
+    expected_query = (
+        "mimeType='application/vnd.google-apps.document' "
+        f"and (modifiedTime > '{iso_time}' or sharedWithMe = true)"
+    )
+    service.files.return_value.list.assert_called_once_with(
+        q=expected_query,
+        fields="files(id, name, modifiedTime, sharedWithMeTime)",
+        supportsAllDrives=True,
+        includeItemsFromAllDrives=True,
+        corpora="allDrives",
+    )
     assert files[0]["name"] == "Doc1"
 
 
@@ -54,6 +65,9 @@ def test_list_recent_docs_includes_newly_shared_docs():
     service.files.return_value.list.assert_called_once_with(
         q=expected_query,
         fields="files(id, name, modifiedTime, sharedWithMeTime)",
+        supportsAllDrives=True,
+        includeItemsFromAllDrives=True,
+        corpora="allDrives",
     )
     assert files[0]["name"] == "Shared"
 


### PR DESCRIPTION
## Summary
- search all accessible drives and shared items when listing recent Google Docs
- update tests for new Drive query parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed7c6c93083289b5fb458ba6b0504