### PR TITLE
feat: include shared drive docs

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -68,6 +68,9 @@ def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]
         .list(
             q=query,
             fields="files(id, name, modifiedTime, sharedWithMeTime)",
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+            corpora="allDrives",
         )
         .execute()
     )
@@ -79,7 +82,9 @@ def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]
             if not ts:
                 continue
             try:
-                dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00")).replace(
+                    tzinfo=None
+                )
             except ValueError:
                 continue
             if dt > since_time:

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -27,7 +27,18 @@ def test_list_recent_docs_filters_by_time():
     }
     since = datetime(2023, 12, 31, 23, 0, 0)
     files = list_recent_docs(service, since)
-    service.files.assert_called_once()
+    iso_time = since.replace(microsecond=0).isoformat("T") + "Z"
+    expected_query = (
+        "mimeType='application/vnd.google-apps.document' "
+        f"and (modifiedTime > '{iso_time}' or sharedWithMe = true)"
+    )
+    service.files.return_value.list.assert_called_once_with(
+        q=expected_query,
+        fields="files(id, name, modifiedTime, sharedWithMeTime)",
+        supportsAllDrives=True,
+        includeItemsFromAllDrives=True,
+        corpora="allDrives",
+    )
     assert files[0]["name"] == "Doc1"
 
 
@@ -54,8 +65,33 @@ def test_list_recent_docs_includes_newly_shared_docs():
     service.files.return_value.list.assert_called_once_with(
         q=expected_query,
         fields="files(id, name, modifiedTime, sharedWithMeTime)",
+        supportsAllDrives=True,
+        includeItemsFromAllDrives=True,
+        corpora="allDrives",
     )
     assert files[0]["name"] == "Shared"
+
+
+def test_list_recent_docs_parses_microsecond_timestamps():
+    """Timestamps with fractional seconds should be parsed correctly."""
+    service = MagicMock()
+    service.files.return_value.list.return_value.execute.return_value = {
+        "files": [
+            {
+                "id": "1",
+                "name": "Micro",
+                "modifiedTime": "2024-01-02T00:00:00.123456Z",
+            },
+            {
+                "id": "2",
+                "name": "SharedMicro",
+                "sharedWithMeTime": "2024-01-02T00:00:00.654321Z",
+            },
+        ]
+    }
+    since = datetime(2024, 1, 1, 23, 59, 59)
+    files = list_recent_docs(service, since)
+    assert {f["name"] for f in files} == {"Micro", "SharedMicro"}
 
 
 def test_app_properties_roundtrip():


### PR DESCRIPTION
## Summary
- search all accessible drives and shared items when listing recent Google Docs
- parse fractional-second timestamps when filtering to ensure newly shared docs are detected
- update tests for new Drive query parameters and microsecond timestamps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed7c6c93083289b5fb458ba6b0504