### PR TITLE
Fix comment anchoring by accounting for newlines

### DIFF
--- a/src/google_docs.py
+++ b/src/google_docs.py
@@ -38,18 +38,27 @@ def get_document_paragraphs(service: Any, document_id: str) -> List[str]:
 
 
 def chunk_paragraphs(paragraphs: List[str], max_chars: int) -> List[str]:
-    """Chunk paragraphs into groups limited by ``max_chars`` characters."""
+    """Chunk paragraphs into groups limited by ``max_chars`` characters.
+
+    Paragraphs are concatenated using newline characters so that the returned
+    chunks mirror the exact text found in the document. ``max_chars`` therefore
+    includes these newline separators when computing the size of each chunk.
+    """
+
     chunks: List[str] = []
     current: List[str] = []
     current_len = 0
     for para in paragraphs:
-        if current_len + len(para) > max_chars and current:
-            chunks.append("".join(current))
+        # ``para_len`` accounts for a preceding newline when ``current`` already
+        # contains content so that the length matches the document text.
+        para_len = len(para) + (1 if current else 0)
+        if current_len + para_len > max_chars and current:
+            chunks.append("\n".join(current))
             current = [para]
             current_len = len(para)
         else:
             current.append(para)
-            current_len += len(para)
+            current_len += para_len
     if current:
-        chunks.append("".join(current))
+        chunks.append("\n".join(current))
     return chunks

--- a/test/test_google_docs.py
+++ b/test/test_google_docs.py
@@ -20,4 +20,4 @@ def test_get_document_paragraphs():
 def test_chunk_paragraphs():
     paragraphs = ["a" * 10, "b" * 10, "c" * 10]
     chunks = chunk_paragraphs(paragraphs, max_chars=25)
-    assert chunks == ["a" * 10 + "b" * 10, "c" * 10]
+    assert chunks == ["a" * 10 + "\n" + "b" * 10, "c" * 10]

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -68,11 +68,11 @@ def test_process_changed_ranges_chunks_long_range():
     items = process_changed_ranges(paragraphs, changed, suggest)
     assert len(items) == 2
     assert captured == ["a" * 600, "b" * 600]
-    start = len("p0")
+    start = len("p0") + 1
     assert items[0]["start_index"] == start
     assert items[0]["end_index"] == start + 600
-    assert items[1]["start_index"] == start + 600
-    assert items[1]["end_index"] == start + 1200
+    assert items[1]["start_index"] == start + 601
+    assert items[1]["end_index"] == start + 1201
 
 
 def test_review_document_pipeline():
@@ -126,8 +126,8 @@ def test_review_document_pipeline():
     assert len(items) == 1
     assert items[0]["suggestion"] == "Fix typo"
     assert captured["context"] == "share msg"
-    assert items[0]["start_index"] == len("para1")
-    assert items[0]["end_index"] == len("para1") + len("para2 updated")
+    assert items[0]["start_index"] == len("para1") + 1
+    assert items[0]["end_index"] == len("para1") + 1 + len("para2 updated")
 
     expected_hash = _hash("Fix typo", "para2 updated")
     update_body = drive.files.return_value.update.call_args.kwargs["body"]


### PR DESCRIPTION
## Summary
- handle paragraph newlines when chunking document text
- adjust start/end index calculations so comments anchor to the correct text
- update tests for newline-aware offsets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ede8523b88328b057f5e72a622d10