### PR TITLE
Fix Google Drive comment anchors

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -161,15 +161,11 @@ def create_comment(
 
     body: Dict[str, Any] = {"content": content}
     if start_index is not None and end_index is not None:
-        body["anchor"] = json.dumps(
-            {
-                "r": {
-                    "segmentId": "",
-                    "startIndex": start_index,
-                    "endIndex": end_index,
-                }
-            }
-        )
+        # The Drive API expects the anchor payload to use short keys ``s`` and
+        # ``e`` for start and end character offsets within the document's body.
+        # Using ``startIndex``/``endIndex`` causes the Docs UI to fall back to
+        # "Original content deleted" instead of highlighting the intended text.
+        body["anchor"] = json.dumps({"r": {"s": start_index, "e": end_index}})
     if quoted_text is not None:
         body["quotedFileContent"] = {"mimeType": "text/plain", "value": quoted_text}
     return (

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -132,9 +132,7 @@ def test_get_share_message_fetches_description():
 def test_create_and_reply_comment():
     service = MagicMock()
     create_comment(service, "file", "hello", 1, 5, "teh")
-    expected_anchor = json.dumps(
-        {"r": {"segmentId": "", "startIndex": 1, "endIndex": 5}}
-    )
+    expected_anchor = json.dumps({"r": {"s": 1, "e": 5}})
     service.comments.return_value.create.assert_called_once_with(
         fileId="file",
         body={


### PR DESCRIPTION
## Summary
- ensure comment anchors use the Drive API's short `s`/`e` offset keys
- update tests to validate anchor format used by the Docs UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee8d7ccec8328b995e57dd98bceeb