### PR TITLE
Remove AI-specific comment prefix

### DIFF
--- a/src/review.py
+++ b/src/review.py
@@ -220,7 +220,7 @@ def post_comments(drive_service: Any, document_id: str, items: List[Dict[str, st
         return chunks
 
     for item in items:
-        lines = [f"AI Reviewer: {item['hash']}"]
+        lines: List[str] = []
         issue = item.get("issue")
         if issue:
             lines.append(issue)

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -217,9 +217,7 @@ def test_post_comments_calls_create(monkeypatch):
         }
     ]
     post_comments("svc", "doc1", items)
-    assert create_calls == [
-        ("doc1", "AI Reviewer: abcd\nFix typo", 1, 3, "teh")
-    ]
+    assert create_calls == [("doc1", "Fix typo", 1, 3, "teh")]
     assert reply_calls == []
 
 


### PR DESCRIPTION
## Summary
- stop including "AI Reviewer" and hash identifiers in posted comments
- adjust tests to expect plain suggestions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee8cec40083289c8c76d9c68e10cd