### PR TITLE
Handle Groq rate limits and validate Apps Script ID

### DIFF
--- a/src/google_apps_script.py
+++ b/src/google_apps_script.py
@@ -47,16 +47,15 @@ def create_comment(
     -------
     Dict containing the ``id`` of the created comment.
     """
+    script_id = settings.GOOGLE_APPS_SCRIPT_ID
+    if not script_id:
+        raise ValueError("GOOGLE_APPS_SCRIPT_ID is not set")
 
     body: Dict[str, Any] = {
         "function": "addComment",
         "parameters": [document_id, start_index, end_index, content],
     }
-    response = (
-        service.scripts()
-        .run(scriptId=settings.GOOGLE_APPS_SCRIPT_ID, body=body)
-        .execute()
-    )
+    response = service.scripts().run(scriptId=script_id, body=body).execute()
     result = response.get("response", {}).get("result", {})
     if isinstance(result, dict):
         comment_id = result.get("id", "")

--- a/test/test_google_apps_script.py
+++ b/test/test_google_apps_script.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 from src.google_apps_script import create_comment
 from config import settings
+import pytest
 
 
 def test_create_comment_invokes_script(monkeypatch):
@@ -19,4 +20,11 @@ def test_create_comment_invokes_script(monkeypatch):
         scriptId="script123",
         body={"function": "addComment", "parameters": ["doc1", 1, 5, "hello"]},
     )
+
+
+def test_create_comment_requires_script_id(monkeypatch):
+    service = MagicMock()
+    monkeypatch.setattr(settings, "GOOGLE_APPS_SCRIPT_ID", None)
+    with pytest.raises(ValueError):
+        create_comment(service, "doc1", "hi")
 

--- a/test/test_groq_client.py
+++ b/test/test_groq_client.py
@@ -78,7 +78,7 @@ def test_get_suggestions_raises_after_retries(monkeypatch):
 
 
 def test_groq_suggest_extracts_message_content(monkeypatch):
-    def fake_get_suggestions(prompt):
+    def fake_get_suggestions(prompt, **kwargs):
         return {"choices": [{"message": {"content": "Suggestion here"}}]}
 
     monkeypatch.setattr("src.main.get_suggestions", fake_get_suggestions)


### PR DESCRIPTION
## Summary
- Retry Groq requests with extended backoff and warn on 429 rate limits
- Ensure `GOOGLE_APPS_SCRIPT_ID` is provided before creating comments
- Cover missing script ID and suggestion wrapper in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689efab2dbc083288532363b6792d6c4