### PR TITLE
Align Groq rate limiting with official limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 GROQ_API_KEY=your_groq_api_key_here
 GOOGLE_SERVICE_ACCOUNT_JSON=path/to/service_account.json
 GROQ_CHUNK_SIZE=104857
+GROQ_REQUESTS_PER_MINUTE=10 # Groq allows about 10 RPM; higher values may be throttled

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Environment variables are loaded from `.env`:
 | `GOOGLE_SERVICE_ACCOUNT_JSON` | Path to service account credentials |
 | `GOOGLE_APPS_SCRIPT_ID` | ID of deployed Apps Script used for commenting |
 | `GROQ_CHUNK_SIZE` | Max bytes per request to Groq (default `20000`) |
-| `GROQ_REQUESTS_PER_MINUTE` | Rate limit threshold (default `25`) |
+| `GROQ_REQUESTS_PER_MINUTE` | Requests per minute before throttling (default `10`) |
 
 ## Running
 
@@ -50,6 +50,10 @@ Environment variables are loaded from `.env`:
 pip install -r requirements.txt
 python -m src.main
 ```
+
+Set `GROQ_REQUESTS_PER_MINUTE` in your `.env` to match the limits of your Groq plan.
+Exceeding this value results in `429 Too Many Requests`; the client will back off and
+temporarily reduce its rate based on Groq's `Retry-After` hints.
 
 The service checks for new documents every minute and posts comments automatically.
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -7,5 +7,6 @@ GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
 GOOGLE_APPS_SCRIPT_ID = os.getenv("GOOGLE_APPS_SCRIPT_ID")
 GROQ_CHUNK_SIZE = int(os.getenv("GROQ_CHUNK_SIZE", 20000))
-GROQ_REQUESTS_PER_MINUTE = int(os.getenv("GROQ_REQUESTS_PER_MINUTE", 25))
+# Default to Groq's published rate limit of 10 requests per minute
+GROQ_REQUESTS_PER_MINUTE = int(os.getenv("GROQ_REQUESTS_PER_MINUTE", 10))
 

--- a/src/groq_client.py
+++ b/src/groq_client.py
@@ -66,9 +66,21 @@ class RateLimiter:
     """
 
     def __init__(self, requests_per_minute: int) -> None:
-        self.max_calls = max(1, requests_per_minute)
+        self.base_max_calls = max(1, requests_per_minute)
+        self.max_calls = self.base_max_calls
         self.lock = threading.Lock()
         self.calls: deque[float] = deque()
+        self.throttle_reset = 0.0
+
+    def reduce_rate(self, retry_after: float) -> None:
+        """Temporarily slow the rate based on a ``Retry-After`` hint."""
+        with self.lock:
+            try:
+                new_rate = int(60 / retry_after)
+            except Exception:
+                new_rate = 1
+            self.max_calls = max(1, min(self.max_calls, new_rate))
+            self.throttle_reset = max(self.throttle_reset, time.time() + retry_after)
 
     def acquire(self) -> None:
         """Block until another call is allowed.
@@ -79,10 +91,13 @@ class RateLimiter:
         back-to-back requests that could trigger rate limits.
         """
 
-        min_interval = 60 / self.max_calls
         while True:
             with self.lock:
                 now = time.time()
+                if self.throttle_reset and now >= self.throttle_reset:
+                    self.max_calls = self.base_max_calls
+                    self.throttle_reset = 0.0
+                min_interval = 60 / self.max_calls
                 # Remove timestamps outside the 60 second window
                 while self.calls and now - self.calls[0] >= 60:
                     self.calls.popleft()
@@ -93,14 +108,8 @@ class RateLimiter:
                     self.calls.append(now)
                     return
 
-                # Only apply the 60-second sliding window wait if we've already
-                # reached the maximum number of calls for the window. When below
-                # the limit we only need to enforce the minimum spacing between
-                # consecutive calls.
                 wait_window = (
-                    self.calls[0] + 60 - now
-                    if len(self.calls) >= self.max_calls
-                    else 0
+                    self.calls[0] + 60 - now if len(self.calls) >= self.max_calls else 0
                 )
                 wait_spacing = (
                     self.calls[-1] + min_interval - now if self.calls else 0
@@ -176,6 +185,7 @@ def get_suggestions(
                         wait = float(retry_after)
                     except (TypeError, ValueError):
                         wait = _backoff
+                    rate_limiter.reduce_rate(wait)
                     jitter = random.uniform(0, wait / 2)
                     logger.warning(
                         "Groq rate limited (429). Retrying in %.2f seconds (attempt %s/%s)",

--- a/test/test_groq_client.py
+++ b/test/test_groq_client.py
@@ -195,6 +195,37 @@ def test_rate_limiter_sliding_window(monkeypatch):
     assert sleeps == [10.0]
 
 
+def test_rate_limiter_reduce_rate(monkeypatch):
+    import src.groq_client as gc
+    from src.groq_client import RateLimiter
+
+    times = [0.0]
+    sleeps: list[float] = []
+
+    def fake_time() -> float:
+        return times[0]
+
+    def fake_sleep(s: float) -> None:
+        sleeps.append(s)
+        times[0] += s
+
+    monkeypatch.setattr(gc.time, "time", fake_time)
+    monkeypatch.setattr(gc.time, "sleep", fake_sleep)
+
+    rl = RateLimiter(60)
+    rl.reduce_rate(5)
+    rl.acquire()
+    rl.acquire()
+
+    # Second call should wait 5 seconds due to throttling
+    assert sleeps == [5.0]
+
+    # Advance time past the cooldown and ensure rate restores
+    times[0] = 11
+    rl.acquire()
+    assert rl.max_calls == rl.base_max_calls
+
+
 def test_rate_limiter_thread_safety(monkeypatch):
     import threading
     import src.groq_client as gc


### PR DESCRIPTION
## Summary
- Default Groq request rate lowered to 10 RPM and documented in sample environment file
- Rate limiter now slows future requests when repeated 429s occur via Retry-After hints
- README expanded with guidance on configuring and respecting Groq request limits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1d72bf218832896485b9f3e614049