### PR TITLE
Document Apps Script ID configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 GROQ_API_KEY=your_groq_api_key_here
 GOOGLE_SERVICE_ACCOUNT_JSON=path/to/service_account.json
+GOOGLE_APPS_SCRIPT_ID=
 GROQ_CHUNK_SIZE=104857

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Environment variables are loaded from `.env`:
 | -------- | ----------- |
 | `GROQ_API_KEY` | Groq API token |
 | `GOOGLE_SERVICE_ACCOUNT_JSON` | Path to service account credentials |
-| `GOOGLE_APPS_SCRIPT_ID` | ID of deployed Apps Script used for commenting |
+| `GOOGLE_APPS_SCRIPT_ID` | ID of deployed Apps Script used for commenting<br>1. Open the Apps Script project.<br>2. Go to **Project Settings** → copy the **Script ID**.<br>3. Place it in `.env` as `GOOGLE_APPS_SCRIPT_ID=<copied_id>`. |
 | `GROQ_CHUNK_SIZE` | Max bytes per request to Groq (default `20000`) |
 | `GROQ_REQUESTS_PER_MINUTE` | Rate limit threshold (default `25`) |
 


### PR DESCRIPTION
## Summary
- add `GOOGLE_APPS_SCRIPT_ID` placeholder to `.env.example`
- expand README config instructions with steps to fetch Apps Script ID

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1d74466ec8328a0541bebe43753cb