### PR TITLE
docs: document workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Provide an autonomous **"boss" reviewer** that reviews documents shared with a s
 * 🔍 **Change tracking** – Detects changes by comparing the latest revision with the last reviewed version.
 * 🤖 **LLM suggestions** – Sends edited text to Groq's Chat Completions API with chunking, retries, and rate limiting.
 * 💬 **Automated comments** – Uses Google Apps Script Execution API to anchor comments at precise text offsets.
-* 🧹 **Deduplication** – Prevents repeated comments via hashed suggestion storage in Drive `appProperties`.
+* 📝 **Context-aware feedback** – Treats a document's description as extra context for the reviewer.
+* ♻️ **Revision-aware deduplication** – Stores the last reviewed revision and hashed suggestions in Drive `appProperties` to skip repeated comments.
 * ⏱ **Scheduled runner** – Runs `main.py` periodically using the `schedule` library.
 
 ---
@@ -37,6 +38,37 @@ Provide an autonomous **"boss" reviewer** that reviews documents shared with a s
 4. **`src/review.py`** – Orchestrates review: change detection → suggestion generation → deduplication → posting.
 5. **`src/groq_client.py`** – Handles Groq API requests with retries, chunking, and rate limiting.
 6. **`src/google_apps_script.py`** – Invokes Apps Script for text‑anchored inline comments.
+
+---
+
+## 🔄 Workflow
+
+```mermaid
+flowchart TD
+    A[Start `main.py`] --> B[Init Drive, Docs, Apps Script services]
+    B --> C[Set `since` timestamp]
+    C --> D{Every minute}
+    D --> E[List docs changed since `since`]
+    E --> F[Review & comment on each doc]
+    F --> G[Update `since` to latest change]
+    G --> D
+```
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as ClearMyBoss
+    participant GDocs as Google Docs/Drive
+    participant LLM as Groq API
+
+    U->>GDocs: Share or edit doc
+    C->>GDocs: Poll for updated docs
+    C->>GDocs: Fetch paragraphs & metadata
+    C->>LLM: Request suggestions
+    LLM-->>C: Return feedback
+    C->>GDocs: Post comments via Apps Script
+    GDocs-->>U: Comments appear in doc
+```
 
 ---
 
@@ -65,6 +97,8 @@ Environment variables are loaded from `.env`:
 ---
 
 ## ▶️ Running
+
+Share or edit a Google Doc with the service account in your credentials. Optional: add background context in the file's **Description** field so the reviewer understands the goal.
 
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- clarify that the document description is used as context and that revision IDs prevent duplicate comments
- add workflow diagrams showing the scheduled runner and user interaction
- mention sharing the doc with the service account and optional description context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2bc5de4c48328b3e3a277b4fb8c73