### PR TITLE
feat: support anchored comments

### DIFF
--- a/src/google_apps_script.py
+++ b/src/google_apps_script.py
@@ -23,14 +23,13 @@ def build_script_service() -> Any:
     return build("script", "v1", credentials=creds)
 
 
-def create_comment(
+def create_anchored_comment(
     service: Any,
     document_id: str,
     content: str,
-    start_index: int | None = None,
-    end_index: int | None = None,
+    anchor: Dict[str, int] | None = None,
 ) -> Dict[str, str]:
-    """Add a text-anchored comment via an Apps Script function.
+    """Add an anchored comment via an Apps Script function.
 
     Parameters
     ----------
@@ -40,8 +39,9 @@ def create_comment(
         ID of the document to comment on.
     content
         Text content of the comment.
-    start_index, end_index
-        Character offsets within the document's body to anchor the comment.
+    anchor
+        JSON dict specifying the text range to anchor the comment. The dict
+        should include ``startIndex`` and ``endIndex`` keys.
 
     Returns
     -------
@@ -52,8 +52,8 @@ def create_comment(
         raise ValueError("GOOGLE_APPS_SCRIPT_ID is not set")
 
     body: Dict[str, Any] = {
-        "function": "addComment",
-        "parameters": [document_id, start_index, end_index, content],
+        "function": "addAnchoredComment",
+        "parameters": [document_id, anchor, content],
     }
     response = service.scripts().run(scriptId=script_id, body=body).execute()
     result = response.get("response", {}).get("result", {})

--- a/src/review.py
+++ b/src/review.py
@@ -6,7 +6,7 @@ import logging
 from difflib import SequenceMatcher
 
 from .google_docs import chunk_paragraphs, get_document_paragraphs
-from .google_apps_script import create_comment
+from .google_apps_script import create_anchored_comment
 from .google_drive import (
     download_revision_text,
     get_app_properties,
@@ -233,12 +233,15 @@ def post_comments(
         content = "\n".join(lines)
         parts = _chunk_content(content)
         # Post the first part anchored to the text range
-        comment = create_comment(
+        anchor = {
+            "startIndex": item.get("start_index"),
+            "endIndex": item.get("end_index"),
+        }
+        comment = create_anchored_comment(
             script_service,
             document_id,
             parts[0],
-            item.get("start_index"),
-            item.get("end_index"),
+            anchor,
         )
         # Post remaining parts as replies
         for part in parts[1:]:

--- a/test/test_google_apps_script.py
+++ b/test/test_google_apps_script.py
@@ -1,11 +1,11 @@
 from unittest.mock import MagicMock
 
-from src.google_apps_script import create_comment
+from src.google_apps_script import create_anchored_comment
 from config import settings
 import pytest
 
 
-def test_create_comment_invokes_script(monkeypatch):
+def test_create_anchored_comment_invokes_script(monkeypatch):
     service = MagicMock()
     service.scripts.return_value.run.return_value.execute.return_value = {
         "response": {"result": {"id": "c1"}}
@@ -13,18 +13,22 @@ def test_create_comment_invokes_script(monkeypatch):
 
     monkeypatch.setattr(settings, "GOOGLE_APPS_SCRIPT_ID", "script123")
 
-    result = create_comment(service, "doc1", "hello", 1, 5)
+    anchor = {"startIndex": 1, "endIndex": 5}
+    result = create_anchored_comment(service, "doc1", "hello", anchor)
 
     assert result == {"id": "c1"}
     service.scripts.return_value.run.assert_called_once_with(
         scriptId="script123",
-        body={"function": "addComment", "parameters": ["doc1", 1, 5, "hello"]},
+        body={
+            "function": "addAnchoredComment",
+            "parameters": ["doc1", anchor, "hello"],
+        },
     )
 
 
-def test_create_comment_requires_script_id(monkeypatch):
+def test_create_anchored_comment_requires_script_id(monkeypatch):
     service = MagicMock()
     monkeypatch.setattr(settings, "GOOGLE_APPS_SCRIPT_ID", None)
     with pytest.raises(ValueError):
-        create_comment(service, "doc1", "hi")
+        create_anchored_comment(service, "doc1", "hi", {"startIndex": 1, "endIndex": 2})
 

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -191,14 +191,14 @@ def test_post_comments_calls_create(monkeypatch):
     create_calls = []
     reply_calls = []
 
-    def fake_create(service, file_id, content, start_index=None, end_index=None):
-        create_calls.append((file_id, content, start_index, end_index))
+    def fake_create(service, file_id, content, anchor):
+        create_calls.append((file_id, content, anchor))
         return {"id": "c1"}
 
     def fake_reply(service, file_id, comment_id, content):
         reply_calls.append((file_id, comment_id, content))
 
-    monkeypatch.setattr("src.review.create_comment", fake_create)
+    monkeypatch.setattr("src.review.create_anchored_comment", fake_create)
     monkeypatch.setattr("src.review.reply_to_comment", fake_reply)
     items = [
         {
@@ -210,7 +210,9 @@ def test_post_comments_calls_create(monkeypatch):
         }
     ]
     post_comments("drive", "script", "doc1", items)
-    assert create_calls == [("doc1", "Fix typo", 1, 3)]
+    assert create_calls == [
+        ("doc1", "Fix typo", {"startIndex": 1, "endIndex": 3})
+    ]
     assert reply_calls == []
 
 
@@ -218,14 +220,14 @@ def test_post_comments_splits_long_comments(monkeypatch):
     create_calls = []
     reply_calls = []
 
-    def fake_create(service, file_id, content, start_index=None, end_index=None):
-        create_calls.append((file_id, content, start_index, end_index))
+    def fake_create(service, file_id, content, anchor):
+        create_calls.append((file_id, content, anchor))
         return {"id": "c1"}
 
     def fake_reply(service, file_id, comment_id, content):
         reply_calls.append((file_id, comment_id, content))
 
-    monkeypatch.setattr("src.review.create_comment", fake_create)
+    monkeypatch.setattr("src.review.create_anchored_comment", fake_create)
     monkeypatch.setattr("src.review.reply_to_comment", fake_reply)
 
     long_text = "a" * 5000


### PR DESCRIPTION
## Summary
- replace `create_comment` with `create_anchored_comment`
- include start and end indices in anchor JSON
- keep existing reply flow for multi-part comments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a325e728c8832895e0d013245d93d5