### PR TITLE
Use Apps Script for precise anchored comments

### DIFF
--- a/src/google_apps_script.py
+++ b/src/google_apps_script.py
@@ -63,3 +63,42 @@ def create_comment(
         comment_id = str(result)
     return {"id": comment_id}
 
+
+def create_anchored_comment(
+    service: Any,
+    document_id: str,
+    content: str,
+    anchor: Dict[str, Any] | None,
+) -> Dict[str, str]:
+    """Add a comment anchored to a specific range via Apps Script.
+
+    Parameters
+    ----------
+    service:
+        Authenticated Apps Script service instance.
+    document_id:
+        ID of the document to comment on.
+    content:
+        Text content of the comment.
+    anchor:
+        JSON object containing ``startIndex`` and ``endIndex`` keys specifying
+        the document range to anchor the comment to.
+
+    Returns
+    -------
+    Dict containing the ``id`` of the created comment.
+    """
+
+    script_id = settings.GOOGLE_APPS_SCRIPT_ID
+    if not script_id:
+        raise ValueError("GOOGLE_APPS_SCRIPT_ID is not set")
+
+    body: Dict[str, Any] = {
+        "function": "addAnchoredComment",
+        "parameters": [document_id, anchor, content],
+    }
+    response = service.scripts().run(scriptId=script_id, body=body).execute()
+    result = response.get("response", {}).get("result", {})
+    comment_id = result.get("id", "") if isinstance(result, dict) else str(result)
+    return {"id": comment_id}
+

--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-import json
 import os
-import json
 from typing import List, Dict, Any
 
 from google.oauth2 import service_account
@@ -135,18 +133,6 @@ def get_share_message(service: Any, file_id: str) -> str:
     return result.get("description", "")
 
 
-def create_anchored_comment(
-    service: Any, file_id: str, content: str, anchor: str | None
-) -> Any:
-    """Create a comment anchored to a text range."""
-    body: Dict[str, Any] = {"content": content}
-    if anchor:
-        body["anchor"] = anchor
-    return (
-        service.comments().create(fileId=file_id, body=body, fields="id").execute()
-    )
-
-
 def reply_to_comment(
     service: Any, file_id: str, comment_id: str, content: str
 ) -> Any:
@@ -157,54 +143,6 @@ def reply_to_comment(
         .create(fileId=file_id, commentId=comment_id, body=body, fields="id")
         .execute()
     )
-
-
-def create_anchored_comment(
-    service: Any,
-    file_id: str,
-    content: str,
-    start_index: int,
-    end_index: int,
-) -> str:
-    """Create a new comment anchored to a text range.
-
-    Parameters
-    ----------
-    service
-        Authenticated Google Drive service instance.
-    file_id
-        ID of the document to comment on.
-    content
-        Comment text.
-    start_index, end_index
-        Text range to anchor the comment to.
-
-    Returns
-    -------
-    str
-        The ID of the created comment.
-    """
-
-    anchor = json.dumps(
-        {
-            "r": "head",
-            "a": [
-                {
-                    "txt": {
-                        "start_index": start_index,
-                        "end_index": end_index,
-                    }
-                }
-            ],
-        }
-    )
-    body = {"content": content, "anchor": anchor}
-    result = (
-        service.comments()
-        .create(fileId=file_id, body=body, fields="id")
-        .execute()
-    )
-    return result.get("id", "")
 
 
 def list_comments(service: Any, file_id: str) -> List[Dict[str, Any]]:

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from .google_drive import build_drive_service, list_recent_docs
 from .google_docs import build_docs_service
+from .google_apps_script import build_script_service
 from .groq_client import get_suggestions
 from requests import HTTPError
 from .review import review_document, post_comments
@@ -53,7 +54,9 @@ def groq_suggest(text: str, context: str) -> dict[str, str]:
         return {"issue": "", "suggestion": "", "severity": "info"}
 
 
-def run_once(drive_service: Any, docs_service: Any, since: datetime) -> datetime:
+def run_once(
+    script_service: Any, drive_service: Any, docs_service: Any, since: datetime
+) -> datetime:
     """Process documents changed since ``since`` and return new timestamp.
 
     Documents are considered changed if they were modified or newly shared with
@@ -84,7 +87,7 @@ def run_once(drive_service: Any, docs_service: Any, since: datetime) -> datetime
                 )
 
                 if items:
-                    post_comments(drive_service, doc_id, items)
+                    post_comments(script_service, drive_service, doc_id, items)
                     logger.info(
                         "Posted %d comments to document '%s'", len(items), doc_name
                     )
@@ -135,10 +138,14 @@ def main() -> None:
         logger.info("Initializing Google Drive service...")
         drive_service = build_drive_service()
         logger.info("Google Drive service initialized successfully")
-        
+
         logger.info("Initializing Google Docs service...")
         docs_service = build_docs_service()
         logger.info("Google Docs service initialized successfully")
+
+        logger.info("Initializing Apps Script service...")
+        script_service = build_script_service()
+        logger.info("Apps Script service initialized successfully")
 
         since = datetime.utcnow()
         logger.info(f"Initial timestamp set to: {since}")
@@ -149,7 +156,7 @@ def main() -> None:
             nonlocal since
             logger.info("=" * 60)
             logger.info("Scheduled job triggered - starting document review")
-            since = run_once(drive_service, docs_service, since)
+            since = run_once(script_service, drive_service, docs_service, since)
             logger.info("Scheduled job completed")
             logger.info("=" * 60)
         

--- a/src/review.py
+++ b/src/review.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, Callable, Dict, List, Set, Tuple
 import hashlib
 import logging
-import json
 from difflib import SequenceMatcher
 
 from .google_docs import chunk_paragraphs, get_document_paragraphs
@@ -13,8 +12,8 @@ from .google_drive import (
     get_share_message,
     update_app_properties,
     reply_to_comment,
-    create_anchored_comment,
 )
+from .google_apps_script import create_anchored_comment
 
 
 # Maximum allowed bytes for a single app property (key + value).
@@ -198,6 +197,7 @@ def review_document(
 
 
 def post_comments(
+    script_service: Any,
     drive_service: Any,
     document_id: str,
     items: List[Dict[str, str]],
@@ -237,11 +237,9 @@ def post_comments(
         end = item.get("end_index")
         anchor = None
         if start is not None and end is not None:
-            anchor = json.dumps(
-                {"r": {"segmentId": "", "startIndex": start, "endIndex": end}}
-            )
+            anchor = {"segmentId": "", "startIndex": start, "endIndex": end}
         comment = create_anchored_comment(
-            drive_service, document_id, parts[0], anchor
+            script_service, document_id, parts[0], anchor
         )
         # Post remaining parts as replies
         for part in parts[1:]:

--- a/test/test_google_apps_script.py
+++ b/test/test_google_apps_script.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock
+
+from src.google_apps_script import create_anchored_comment
+
+
+def test_create_anchored_comment(monkeypatch):
+    monkeypatch.setattr(
+        "src.google_apps_script.settings.GOOGLE_APPS_SCRIPT_ID", "script123"
+    )
+    service = MagicMock()
+    service.scripts.return_value.run.return_value.execute.return_value = {
+        "response": {"result": {"id": "c1"}}
+    }
+    anchor = {"segmentId": "", "startIndex": 1, "endIndex": 3}
+    result = create_anchored_comment(service, "doc", "hello", anchor)
+    assert result == {"id": "c1"}
+    body = {
+        "function": "addAnchoredComment",
+        "parameters": ["doc", anchor, "hello"],
+    }
+    service.scripts.return_value.run.assert_called_once_with(
+        scriptId="script123", body=body
+    )

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
-import json
 import pytest
 
 from src.google_drive import (
@@ -14,7 +13,6 @@ from src.google_drive import (
     list_comments,
     list_replies,
     filter_user_comments,
-    create_anchored_comment,
 )
 
 
@@ -126,17 +124,6 @@ def test_get_share_message_fetches_description():
     assert msg == "context"
     service.files.return_value.get.assert_called_once_with(
         fileId="file", fields="description"
-    )
-
-
-def test_create_anchored_comment():
-    service = MagicMock()
-    service.comments.return_value.create.return_value.execute.return_value = {"id": "c1"}
-    anchor = json.dumps({"r": {"segmentId": "", "startIndex": 1, "endIndex": 3}})
-    result = create_anchored_comment(service, "file", "hi", anchor)
-    assert result == {"id": "c1"}
-    service.comments.return_value.create.assert_called_once_with(
-        fileId="file", body={"content": "hi", "anchor": anchor}, fields="id"
     )
 
 

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -1,5 +1,4 @@
 from unittest.mock import MagicMock
-import json
 
 from src.review import (
     _hash,
@@ -210,8 +209,8 @@ def test_post_comments_calls_create(monkeypatch):
             "end_index": 3,
         }
     ]
-    post_comments("drive", "doc1", items)
-    expected_anchor = json.dumps({"r": {"segmentId": "", "startIndex": 1, "endIndex": 3}})
+    post_comments("script", "drive", "doc1", items)
+    expected_anchor = {"segmentId": "", "startIndex": 1, "endIndex": 3}
     assert create_calls == [("doc1", "Fix typo", expected_anchor)]
     assert reply_calls == []
 
@@ -240,7 +239,7 @@ def test_post_comments_splits_long_comments(monkeypatch):
             "end_index": 1,
         }
     ]
-    post_comments("drive", "doc1", items)
+    post_comments("script", "drive", "doc1", items)
 
     # First chunk is posted as the main comment, remaining as replies
     assert len(create_calls) == 1
@@ -248,7 +247,7 @@ def test_post_comments_splits_long_comments(monkeypatch):
     # Ensure the created comment respects size limit
     assert len(create_calls[0][1].encode("utf-8")) <= 4096
     assert len(reply_calls[0][2].encode("utf-8")) <= 4096
-    expected_anchor = json.dumps({"r": {"segmentId": "", "startIndex": 0, "endIndex": 1}})
+    expected_anchor = {"segmentId": "", "startIndex": 0, "endIndex": 1}
     assert create_calls[0][2] == expected_anchor
 
 

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -5,6 +5,7 @@ from src.main import run_once
 
 
 def test_run_once_reviews_and_posts(monkeypatch):
+    script = MagicMock()
     drive = MagicMock()
     docs = MagicMock()
     monkeypatch.setattr(
@@ -23,13 +24,13 @@ def test_run_once_reviews_and_posts(monkeypatch):
 
     posted = []
 
-    def fake_post(drive_service, doc_id, items):
+    def fake_post(script_service, drive_service, doc_id, items):
         posted.append((doc_id, items))
 
     monkeypatch.setattr("src.main.post_comments", fake_post)
 
     since = datetime.utcnow()
-    new_since = run_once(drive, docs, since)
+    new_since = run_once(script, drive, docs, since)
 
     assert posted == [(
         "1",


### PR DESCRIPTION
## Summary
- add `create_anchored_comment` utility calling Apps Script `addAnchoredComment`
- build anchor JSON from review items and post comments via Apps Script
- initialize Apps Script service and pass it through review workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a32acc19d48328b6b898d512852f09