### PR TITLE
Support revision and region anchors for Drive comments

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -139,12 +139,15 @@ def create_comment(
     service: Any,
     file_id: str,
     content: str,
-    anchor: Dict[str, Any] | None = None,
+    revision_id: str = "head",
+    regions: List[dict] | None = None,
 ) -> Dict[str, str]:
     """Create a comment on ``file_id`` optionally anchored to a text range."""
     body: Dict[str, Any] = {"content": content}
-    if anchor is not None:
-        body["anchor"] = json.dumps({"r": anchor})
+    anchor_dict: Dict[str, Any] = {"r": revision_id}
+    if regions is not None:
+        anchor_dict["a"] = regions
+    body["anchor"] = json.dumps(anchor_dict)
     return (
         service.comments()
         .create(fileId=file_id, body=body, fields="id")

--- a/src/review.py
+++ b/src/review.py
@@ -238,7 +238,10 @@ def post_comments(
         if start is not None and end is not None:
             anchor = {"segmentId": "", "startIndex": start, "endIndex": end}
         comment = create_comment(
-            drive_service, document_id, parts[0], anchor
+            drive_service,
+            document_id,
+            parts[0],
+            regions=[anchor] if anchor else None,
         )
         # Post remaining parts as replies
         for part in parts[1:]:

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -190,9 +190,12 @@ def test_create_comment_calls_api(monkeypatch):
     service = MagicMock()
     service.comments.return_value.create.return_value.execute.return_value = {"id": "c1"}
     anchor = {"segmentId": "", "startIndex": 1, "endIndex": 3}
-    result = create_comment(service, "doc", "hello", anchor)
+    result = create_comment(service, "doc", "hello", regions=[anchor])
     assert result == {"id": "c1"}
-    body = {"content": "hello", "anchor": json.dumps({"r": anchor})}
+    body = {
+        "content": "hello",
+        "anchor": json.dumps({"r": "head", "a": [anchor]}),
+    }
     service.comments.return_value.create.assert_called_once_with(
         fileId="doc", body=body, fields="id"
     )

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -191,8 +191,8 @@ def test_post_comments_calls_create(monkeypatch):
     create_calls = []
     reply_calls = []
 
-    def fake_create(service, file_id, content, anchor):
-        create_calls.append((file_id, content, anchor))
+    def fake_create(service, file_id, content, revision_id="head", regions=None):
+        create_calls.append((file_id, content, revision_id, regions))
         return {"id": "c1"}
 
     def fake_reply(service, file_id, comment_id, content):
@@ -211,7 +211,7 @@ def test_post_comments_calls_create(monkeypatch):
     ]
     post_comments("drive", "doc1", items)
     expected_anchor = {"segmentId": "", "startIndex": 1, "endIndex": 3}
-    assert create_calls == [("doc1", "Fix typo", expected_anchor)]
+    assert create_calls == [("doc1", "Fix typo", "head", [expected_anchor])]
     assert reply_calls == []
 
 
@@ -219,8 +219,8 @@ def test_post_comments_splits_long_comments(monkeypatch):
     create_calls = []
     reply_calls = []
 
-    def fake_create(service, file_id, content, anchor):
-        create_calls.append((file_id, content, anchor))
+    def fake_create(service, file_id, content, revision_id="head", regions=None):
+        create_calls.append((file_id, content, revision_id, regions))
         return {"id": "c1"}
 
     def fake_reply(service, file_id, comment_id, content):
@@ -248,7 +248,7 @@ def test_post_comments_splits_long_comments(monkeypatch):
     assert len(create_calls[0][1].encode("utf-8")) <= 4096
     assert len(reply_calls[0][2].encode("utf-8")) <= 4096
     expected_anchor = {"segmentId": "", "startIndex": 0, "endIndex": 1}
-    assert create_calls[0][2] == expected_anchor
+    assert create_calls[0][3] == [expected_anchor]
 
 
 def test_suggestion_hashes_property_total_size_limit():


### PR DESCRIPTION
## Summary
- extend `create_comment` to accept revision id and regions
- pass constructed anchor data when posting comments
- adjust tests for new signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3c1126e848328b6ae5c2a08d69ee1