### PR TITLE
Use line-based anchors for Drive comments

### DIFF
--- a/src/review.py
+++ b/src/review.py
@@ -222,6 +222,8 @@ def post_comments(
             chunks.append(chunk)
             encoded = encoded[len(chunk.encode("utf-8")) :]
         return chunks
+    # Retrieve plain text of the latest revision so we can derive line numbers
+    document_text = download_revision_text(drive_service, document_id, "head")
 
     for item in items:
         lines: List[str] = []
@@ -234,14 +236,18 @@ def post_comments(
         # Post the first part anchored to the text range
         start = item.get("start_index")
         end = item.get("end_index")
-        anchor = None
+        regions = None
         if start is not None and end is not None:
-            anchor = {"segmentId": "", "startIndex": start, "endIndex": end}
+            start_line = document_text.count("\n", 0, start) + 1
+            end_line = document_text.count("\n", 0, max(end - 1, 0)) + 1
+            line_count = end_line - start_line + 1
+            regions = [{"line": {"n": start_line, "l": line_count}}]
         comment = create_comment(
             drive_service,
             document_id,
             parts[0],
-            regions=[anchor] if anchor else None,
+            revision_id="head",
+            regions=regions,
         )
         # Post remaining parts as replies
         for part in parts[1:]:

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -200,6 +200,9 @@ def test_post_comments_calls_create(monkeypatch):
 
     monkeypatch.setattr("src.review.create_comment", fake_create)
     monkeypatch.setattr("src.review.reply_to_comment", fake_reply)
+    monkeypatch.setattr(
+        "src.review.download_revision_text", lambda *_args, **_kwargs: "abc\n"
+    )
     items = [
         {
             "suggestion": "Fix typo",
@@ -210,8 +213,8 @@ def test_post_comments_calls_create(monkeypatch):
         }
     ]
     post_comments("drive", "doc1", items)
-    expected_anchor = {"segmentId": "", "startIndex": 1, "endIndex": 3}
-    assert create_calls == [("doc1", "Fix typo", "head", [expected_anchor])]
+    expected_region = {"line": {"n": 1, "l": 1}}
+    assert create_calls == [("doc1", "Fix typo", "head", [expected_region])]
     assert reply_calls == []
 
 
@@ -228,6 +231,9 @@ def test_post_comments_splits_long_comments(monkeypatch):
 
     monkeypatch.setattr("src.review.create_comment", fake_create)
     monkeypatch.setattr("src.review.reply_to_comment", fake_reply)
+    monkeypatch.setattr(
+        "src.review.download_revision_text", lambda *_args, **_kwargs: "abc\n"
+    )
 
     long_text = "a" * 5000
     items = [
@@ -247,8 +253,8 @@ def test_post_comments_splits_long_comments(monkeypatch):
     # Ensure the created comment respects size limit
     assert len(create_calls[0][1].encode("utf-8")) <= 4096
     assert len(reply_calls[0][2].encode("utf-8")) <= 4096
-    expected_anchor = {"segmentId": "", "startIndex": 0, "endIndex": 1}
-    assert create_calls[0][3] == [expected_anchor]
+    expected_region = {"line": {"n": 1, "l": 1}}
+    assert create_calls[0][3] == [expected_region]
 
 
 def test_suggestion_hashes_property_total_size_limit():


### PR DESCRIPTION
## Summary
- derive line numbers for suggestions and build Drive API region anchors
- call `create_comment` with `revision_id="head"` and new regions
- adjust tests to expect line-based comment anchors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3c343b79c8328917d0d5f59eb1850