### PR TITLE
test: expect region objects in comments

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+def make_region(n: int = 1, l: int = 1) -> dict:
+    """Return a simple line-based region object for tests."""
+    return {"line": {"n": n, "l": l}}
+
+@pytest.fixture
+def region() -> dict:
+    """Default region representing the first line."""
+    return make_region()

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -186,15 +186,14 @@ def test_build_drive_service_missing_credentials(monkeypatch):
     with pytest.raises(ValueError):
         build_drive_service()
 
-def test_create_comment_calls_api(monkeypatch):
+def test_create_comment_calls_api(region):
     service = MagicMock()
     service.comments.return_value.create.return_value.execute.return_value = {"id": "c1"}
-    anchor = {"segmentId": "", "startIndex": 1, "endIndex": 3}
-    result = create_comment(service, "doc", "hello", regions=[anchor])
+    result = create_comment(service, "doc", "hello", regions=[region])
     assert result == {"id": "c1"}
     body = {
         "content": "hello",
-        "anchor": json.dumps({"r": "head", "a": [anchor]}),
+        "anchor": json.dumps({"r": "head", "a": [region]}),
     }
     service.comments.return_value.create.assert_called_once_with(
         fileId="doc", body=body, fields="id"

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -187,7 +187,7 @@ def test_review_document_ignores_empty_suggestions():
     assert update_body["appProperties"]["suggestionHashes"] == "abcd"
 
 
-def test_post_comments_calls_create(monkeypatch):
+def test_post_comments_calls_create(monkeypatch, region):
     create_calls = []
     reply_calls = []
 
@@ -213,12 +213,11 @@ def test_post_comments_calls_create(monkeypatch):
         }
     ]
     post_comments("drive", "doc1", items)
-    expected_region = {"line": {"n": 1, "l": 1}}
-    assert create_calls == [("doc1", "Fix typo", "head", [expected_region])]
+    assert create_calls == [("doc1", "Fix typo", "head", [region])]
     assert reply_calls == []
 
 
-def test_post_comments_splits_long_comments(monkeypatch):
+def test_post_comments_splits_long_comments(monkeypatch, region):
     create_calls = []
     reply_calls = []
 
@@ -253,8 +252,7 @@ def test_post_comments_splits_long_comments(monkeypatch):
     # Ensure the created comment respects size limit
     assert len(create_calls[0][1].encode("utf-8")) <= 4096
     assert len(reply_calls[0][2].encode("utf-8")) <= 4096
-    expected_region = {"line": {"n": 1, "l": 1}}
-    assert create_calls[0][3] == [expected_region]
+    assert create_calls[0][3] == [region]
 
 
 def test_suggestion_hashes_property_total_size_limit():


### PR DESCRIPTION
## Summary
- add helper fixture for region objects used by tests
- expect create_comment to serialize region objects
- verify post_comments passes region classifier objects to create_comment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c57f7f58832885bc5bbc68f9d758