### PR TITLE
refactor: centralize Google service builder

### DIFF
--- a/src/google_docs.py
+++ b/src/google_docs.py
@@ -3,20 +3,13 @@ from __future__ import annotations
 
 from typing import List, Any
 
-from google.oauth2 import service_account
-from googleapiclient.discovery import build
-
-from config import settings
+from .google_service import build_service
 
 SCOPES = ["https://www.googleapis.com/auth/documents.readonly"]
 
 
 def build_docs_service() -> Any:
-    creds = service_account.Credentials.from_service_account_file(
-        settings.GOOGLE_SERVICE_ACCOUNT_JSON, scopes=SCOPES
-    )
-    service = build("docs", "v1", credentials=creds)
-    return service
+    return build_service("docs", "v1", SCOPES)
 
 
 def get_document_paragraphs(service: Any, document_id: str) -> List[str]:

--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -2,13 +2,9 @@
 from __future__ import annotations
 
 from datetime import datetime
-import os
 from typing import List, Dict, Any
 
-from google.oauth2 import service_account
-from googleapiclient.discovery import build
-
-from config import settings
+from .google_service import build_service
 
 import json
 
@@ -16,31 +12,8 @@ SCOPES = ["https://www.googleapis.com/auth/drive"]
 
 
 def build_drive_service() -> Any:
-    """Build an authenticated Drive API service using service account credentials.
-
-    Raises
-    ------
-    ValueError
-        If ``GOOGLE_SERVICE_ACCOUNT_JSON`` is not set in the environment.
-    FileNotFoundError
-        If the path specified by ``GOOGLE_SERVICE_ACCOUNT_JSON`` does not exist.
-    """
-
-    cred_path = settings.GOOGLE_SERVICE_ACCOUNT_JSON
-    if not cred_path:
-        raise ValueError(
-            "GOOGLE_SERVICE_ACCOUNT_JSON environment variable is not set."
-        )
-    if not os.path.exists(cred_path):
-        raise FileNotFoundError(
-            f"Service account JSON file not found at {cred_path}"
-        )
-
-    creds = service_account.Credentials.from_service_account_file(
-        cred_path, scopes=SCOPES
-    )
-    service = build("drive", "v3", credentials=creds)
-    return service
+    """Build an authenticated Drive API service."""
+    return build_service("drive", "v3", SCOPES)
 
 
 def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]:

--- a/src/google_service.py
+++ b/src/google_service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Shared Google API service builder."""
+
+from typing import Any
+import os
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+from config import settings
+
+
+def build_service(api: str, version: str, scopes: list[str]) -> Any:
+    """Create an authenticated Google API client for ``api``.
+
+    Parameters
+    ----------
+    api:
+        Name of the Google API, e.g., ``"drive"`` or ``"docs"``.
+    version:
+        API version string.
+    scopes:
+        OAuth scopes required for the service.
+
+    Raises
+    ------
+    ValueError
+        If the ``GOOGLE_SERVICE_ACCOUNT_JSON`` setting is not configured.
+    FileNotFoundError
+        If the credential file does not exist.
+    """
+
+    cred_path = settings.GOOGLE_SERVICE_ACCOUNT_JSON
+    if not cred_path:
+        raise ValueError(
+            "GOOGLE_SERVICE_ACCOUNT_JSON environment variable is not set."
+        )
+    if not os.path.exists(cred_path):
+        raise FileNotFoundError(
+            f"Service account JSON file not found at {cred_path}"
+        )
+
+    creds = service_account.Credentials.from_service_account_file(
+        cred_path, scopes=scopes
+    )
+    return build(api, version, credentials=creds)

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -181,7 +181,7 @@ def test_filter_user_comments_skips_ai_threads():
 def test_build_drive_service_missing_credentials(monkeypatch):
     """Should raise a clear error when credential path is not configured."""
     monkeypatch.setattr(
-        "src.google_drive.settings.GOOGLE_SERVICE_ACCOUNT_JSON", None
+        "src.google_service.settings.GOOGLE_SERVICE_ACCOUNT_JSON", None
     )
     with pytest.raises(ValueError):
         build_drive_service()


### PR DESCRIPTION
## Summary
- add shared `build_service` helper for Google API clients
- simplify Drive and Docs service constructors to use the helper
- update Drive tests for new import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3caa8608c8328a72d3d850d08c967