### PR TITLE
Remove filter_user_comments helper

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -162,21 +162,3 @@ def list_replies(service: Any, file_id: str, comment_id: str) -> List[Dict[str, 
         .execute()
     )
     return result.get("replies", [])
-
-
-def filter_user_comments(
-    service: Any, file_id: str, ai_display_name: str
-) -> List[Dict[str, Any]]:
-    """Return comment threads whose latest author is not the AI reviewer."""
-    comments = list_comments(service, file_id)
-    user_threads: List[Dict[str, Any]] = []
-    for comment in comments:
-        replies = list_replies(service, file_id, comment["id"])
-        last_author = (
-            replies[-1].get("author", {}).get("displayName", "")
-            if replies
-            else comment.get("author", {}).get("displayName", "")
-        )
-        if last_author != ai_display_name:
-            user_threads.append(comment)
-    return user_threads

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -13,7 +13,6 @@ from src.google_drive import (
     build_drive_service,
     list_comments,
     list_replies,
-    filter_user_comments,
     create_comment,
 )
 
@@ -158,24 +157,6 @@ def test_list_comments_and_replies():
         commentId="c1",
         fields="replies(id,author(displayName),content)",
     )
-
-
-def test_filter_user_comments_skips_ai_threads():
-    service = MagicMock()
-    service.comments.return_value.list.return_value.execute.return_value = {
-        "comments": [
-            {"id": "c1", "author": {"displayName": "User1"}},
-            {"id": "c2", "author": {"displayName": "BossBot"}},
-            {"id": "c3", "author": {"displayName": "User2"}},
-        ]
-    }
-    service.replies.return_value.list.return_value.execute.side_effect = [
-        {"replies": [{"author": {"displayName": "BossBot"}}]},
-        {"replies": []},
-        {"replies": [{"author": {"displayName": "User2"}}]},
-    ]
-    threads = filter_user_comments(service, "file", "BossBot")
-    assert [c["id"] for c in threads] == ["c3"]
 
 
 def test_build_drive_service_missing_credentials(monkeypatch):


### PR DESCRIPTION
## Summary
- drop filter_user_comments helper from Drive utilities
- remove related tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3cbe17dec8328b4d91b3d3b1624e2