### PR TITLE
Use shared helper to parse Google API timestamps

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import List, Dict, Any
 
 from .google_service import build_service
+from .time_utils import parse_google_timestamp
 
 import json
 
@@ -56,9 +57,7 @@ def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]
             if not ts:
                 continue
             try:
-                dt = datetime.fromisoformat(ts.replace("Z", "+00:00")).replace(
-                    tzinfo=None
-                )
+                dt = parse_google_timestamp(ts)
             except ValueError:
                 continue
             if dt > since_time:

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from typing import Any
 from .google_drive import build_drive_service, list_recent_docs
 from .google_docs import build_docs_service
 from .groq_client import get_suggestions
+from .time_utils import parse_google_timestamp
 from requests import HTTPError
 from .review import review_document, post_comments
 
@@ -116,7 +117,7 @@ def run_once(
             ts = f.get(key)
             if ts:
                 try:
-                    dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+                    dt = parse_google_timestamp(ts)
                 except ValueError:
                     continue
                 if dt > latest_time:

--- a/src/time_utils.py
+++ b/src/time_utils.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def parse_google_timestamp(ts: str) -> datetime:
+    """Return naive UTC ``datetime`` from a Google API timestamp string.
+
+    Google APIs return RFC3339 timestamps, e.g. ``"2021-09-15T14:30:00.123Z"``.
+    This helper converts such strings to a timezone-naive ``datetime``.
+    """
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).replace(tzinfo=None)
+


### PR DESCRIPTION
## Summary
- add `parse_google_timestamp` helper for converting Google API timestamps
- use shared helper in Drive listing and scheduler

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3cfa066708328877c73a7a413c550