### PR TITLE
docs: clarify timestamp utility docs

### DIFF
--- a/src/time_utils.py
+++ b/src/time_utils.py
@@ -1,13 +1,25 @@
+"""Utility helpers for parsing Google API timestamps."""
+
 from __future__ import annotations
 
 from datetime import datetime
 
 
 def parse_google_timestamp(ts: str) -> datetime:
-    """Return naive UTC ``datetime`` from a Google API timestamp string.
+    """Convert a Google API RFC3339 timestamp to a naive UTC ``datetime``.
 
     Google APIs return RFC3339 timestamps, e.g. ``"2021-09-15T14:30:00.123Z"``.
     This helper converts such strings to a timezone-naive ``datetime``.
+
+    Parameters
+    ----------
+    ts : str
+        Timestamp string from a Google API in RFC3339 format.
+
+    Returns
+    -------
+    datetime
+        Parsed timestamp as a timezone-naive UTC ``datetime``.
     """
     return datetime.fromisoformat(ts.replace("Z", "+00:00")).replace(tzinfo=None)
 


### PR DESCRIPTION
## Summary
- document time utilities module
- expand parse_google_timestamp with parameters and returns details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3d819ae688328a3bce4c91b51c030