### PR TITLE
Document review pipeline and builtin generics

### DIFF
--- a/src/google_docs.py
+++ b/src/google_docs.py
@@ -1,7 +1,7 @@
 """Google Docs API utilities."""
 from __future__ import annotations
 
-from typing import List, Any
+from typing import Any
 
 from .google_service import build_service
 
@@ -12,10 +12,10 @@ def build_docs_service() -> Any:
     return build_service("docs", "v1", SCOPES)
 
 
-def get_document_paragraphs(service: Any, document_id: str) -> List[str]:
+def get_document_paragraphs(service: Any, document_id: str) -> list[str]:
     """Fetch a document and return its paragraphs as a list of strings."""
     doc = service.documents().get(documentId=document_id).execute()
-    paragraphs: List[str] = []
+    paragraphs: list[str] = []
     for element in doc.get("body", {}).get("content", []):
         para = element.get("paragraph")
         if not para:
@@ -30,7 +30,7 @@ def get_document_paragraphs(service: Any, document_id: str) -> List[str]:
     return paragraphs
 
 
-def chunk_paragraphs(paragraphs: List[str], max_chars: int) -> List[str]:
+def chunk_paragraphs(paragraphs: list[str], max_chars: int) -> list[str]:
     """Chunk paragraphs into groups limited by ``max_chars`` characters.
 
     Paragraphs are concatenated using newline characters so that the returned
@@ -38,8 +38,8 @@ def chunk_paragraphs(paragraphs: List[str], max_chars: int) -> List[str]:
     includes these newline separators when computing the size of each chunk.
     """
 
-    chunks: List[str] = []
-    current: List[str] = []
+    chunks: list[str] = []
+    current: list[str] = []
     current_len = 0
     for para in paragraphs:
         # ``para_len`` accounts for a preceding newline when ``current`` already

--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Dict, Any
+from typing import Any
 
 from .google_service import build_service
 from .time_utils import parse_google_timestamp
@@ -17,7 +17,7 @@ def build_drive_service() -> Any:
     return build_service("drive", "v3", SCOPES)
 
 
-def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]:
+def list_recent_docs(service: Any, since_time: datetime) -> list[dict[str, Any]]:
     """Return Google Docs modified or shared after ``since_time``.
 
     The Drive API does not support filtering by ``sharedWithMeTime`` in the
@@ -50,7 +50,7 @@ def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]
         .execute()
     )
     files = results.get("files", [])
-    recent_files: List[Dict[str, Any]] = []
+    recent_files: list[dict[str, Any]] = []
     for f in files:
         for key in ("modifiedTime", "sharedWithMeTime"):
             ts = f.get(key)
@@ -66,7 +66,7 @@ def list_recent_docs(service: Any, since_time: datetime) -> List[Dict[str, Any]]
     return recent_files
 
 
-def get_app_properties(service: Any, file_id: str) -> tuple[Dict[str, str], str]:
+def get_app_properties(service: Any, file_id: str) -> tuple[dict[str, str], str]:
     """Return ``appProperties`` and ``headRevisionId`` for ``file_id``."""
     result = (
         service.files()
@@ -77,7 +77,7 @@ def get_app_properties(service: Any, file_id: str) -> tuple[Dict[str, str], str]
 
 
 def update_app_properties(
-    service: Any, file_id: str, app_properties: Dict[str, str]
+    service: Any, file_id: str, app_properties: dict[str, str]
 ) -> None:
     """Update ``appProperties`` for ``file_id``."""
     service.files().update(
@@ -112,11 +112,11 @@ def create_comment(
     file_id: str,
     content: str,
     revision_id: str = "head",
-    regions: List[dict] | None = None,
-) -> Dict[str, str]:
+    regions: list[dict] | None = None,
+) -> dict[str, str]:
     """Create a comment on ``file_id`` optionally anchored to a text range."""
-    body: Dict[str, Any] = {"content": content}
-    anchor_dict: Dict[str, Any] = {"r": revision_id}
+    body: dict[str, Any] = {"content": content}
+    anchor_dict: dict[str, Any] = {"r": revision_id}
     if regions is not None:
         anchor_dict["a"] = regions
     body["anchor"] = json.dumps(anchor_dict)
@@ -139,7 +139,7 @@ def reply_to_comment(
     )
 
 
-def list_comments(service: Any, file_id: str) -> List[Dict[str, Any]]:
+def list_comments(service: Any, file_id: str) -> list[dict[str, Any]]:
     """Return top-level comments for ``file_id``."""
     result = (
         service.comments()
@@ -149,7 +149,7 @@ def list_comments(service: Any, file_id: str) -> List[Dict[str, Any]]:
     return result.get("comments", [])
 
 
-def list_replies(service: Any, file_id: str, comment_id: str) -> List[Dict[str, Any]]:
+def list_replies(service: Any, file_id: str, comment_id: str) -> list[dict[str, Any]]:
     """Return replies for a given comment."""
     result = (
         service.replies()

--- a/src/groq_client.py
+++ b/src/groq_client.py
@@ -1,7 +1,7 @@
 """Simple Groq API client for text review suggestions."""
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable
+from typing import Any, Iterable
 
 import logging
 import time
@@ -119,7 +119,7 @@ def get_suggestions(
     retries: int = 3,
     backoff: float = 1.0,
     halt_on_429: bool = True,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Fetch grammar suggestions from Groq.
 
     Large texts are split into ``CHUNK_SIZE`` pieces to keep each request
@@ -132,7 +132,7 @@ def get_suggestions(
         "Content-Type": "application/json",
     }
 
-    def _post(prompt: str) -> Dict[str, Any]:
+    def _post(prompt: str) -> dict[str, Any]:
         payload = {
             "model": "llama-3.1-8b-instant",
             "messages": [

--- a/src/review.py
+++ b/src/review.py
@@ -1,6 +1,12 @@
+"""Core review pipeline for detecting changes and posting feedback.
+
+This module orchestrates document analysis, suggestion generation, de-
+duplication, and comment posting.
+"""
+
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Set, Tuple
+from typing import Any, Callable
 import hashlib
 import logging
 from difflib import SequenceMatcher
@@ -23,8 +29,8 @@ SUGGESTION_HASHES_KEY = "suggestionHashes"
 
 
 def detect_changed_ranges(
-    old_paragraphs: List[str], new_paragraphs: List[str]
-) -> List[Tuple[int, int]]:
+    old_paragraphs: list[str], new_paragraphs: list[str]
+) -> list[tuple[int, int]]:
     """Return index ranges for paragraphs changed between revisions.
 
     Parameters
@@ -39,7 +45,7 @@ def detect_changed_ranges(
     in ``new_paragraphs``.
     """
     matcher = SequenceMatcher(a=old_paragraphs, b=new_paragraphs)
-    ranges: List[Tuple[int, int]] = []
+    ranges: list[tuple[int, int]] = []
     for tag, _, _, j1, j2 in matcher.get_opcodes():
         if tag != "equal":
             ranges.append((j1, j2 - 1))
@@ -47,12 +53,12 @@ def detect_changed_ranges(
 
 
 def process_changed_ranges(
-    paragraphs: List[str],
-    changed_ranges: List[Tuple[int, int]],
-    suggest_fn: Callable[[str, str], Dict[str, Any]],
+    paragraphs: list[str],
+    changed_ranges: list[tuple[int, int]],
+    suggest_fn: Callable[[str, str], dict[str, Any]],
     context: str = "",
     chunk_chars: int = 800,
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Run ``suggest_fn`` on changed text ranges and format results.
 
     Each changed range is further divided into chunks using
@@ -61,13 +67,13 @@ def process_changed_ranges(
     """
     # Pre-compute cumulative character offsets for each paragraph so we can
     # derive ``start_index``/``end_index`` for changed ranges.
-    offsets: List[int] = [0]
+    offsets: list[int] = [0]
     for para in paragraphs:
         # Account for the trailing newline that separates paragraphs in the
         # document's plain-text representation.
         offsets.append(offsets[-1] + len(para) + 1)
 
-    items: List[Dict[str, str]] = []
+    items: list[dict[str, str]] = []
     for start, end in changed_ranges:
         start_offset = offsets[start]
         para_slice = paragraphs[start : end + 1]
@@ -96,10 +102,12 @@ def process_changed_ranges(
 
 
 def _hash(suggestion: str, quote: str) -> str:
+    """Return a short hash used to identify duplicate suggestions."""
+
     return hashlib.sha1(f"{suggestion}|{quote}".encode()).hexdigest()[:8]
 
 
-def _prune_hashes(hashes: List[str], max_bytes: int = 124) -> str:
+def _prune_hashes(hashes: list[str], max_bytes: int = 124) -> str:
     """Join ``hashes`` ensuring result is <= ``max_bytes`` bytes.
 
     Oldest hashes (at the start of ``hashes``) are dropped first if the
@@ -126,10 +134,10 @@ def _prune_hashes(hashes: List[str], max_bytes: int = 124) -> str:
 
 
 def deduplicate_suggestions(
-    items: List[Dict[str, str]], existing_hashes: Set[str]
-) -> List[Dict[str, str]]:
+    items: list[dict[str, str]], existing_hashes: set[str]
+) -> list[dict[str, str]]:
     """Remove suggestions already represented by ``existing_hashes``."""
-    unique: List[Dict[str, str]] = []
+    unique: list[dict[str, str]] = []
     for item in items:
         if not item.get("suggestion"):
             continue
@@ -147,15 +155,15 @@ def review_document(
     drive_service: Any,
     docs_service: Any,
     document_id: str,
-    suggest_fn: Callable[[str, str], Dict[str, Any]],
-) -> List[Dict[str, str]]:
+    suggest_fn: Callable[[str, str], dict[str, Any]],
+) -> list[dict[str, str]]:
     """End-to-end review pipeline for a single document."""
     app_properties, head_revision = get_app_properties(drive_service, document_id)
     last_revision = app_properties.get("lastReviewedRevisionId")
     context = get_share_message(drive_service, document_id)
 
     current_paragraphs = get_document_paragraphs(docs_service, document_id)
-    old_paragraphs: List[str] = []
+    old_paragraphs: list[str] = []
     if last_revision:
         old_text = download_revision_text(drive_service, document_id, last_revision)
         old_paragraphs = old_text.splitlines()
@@ -165,8 +173,8 @@ def review_document(
         current_paragraphs, changed, suggest_fn, context=context
     )
 
-    existing_list: List[str] = []
-    existing_set: Set[str] = set()
+    existing_list: list[str] = []
+    existing_set: set[str] = set()
     if app_properties.get(SUGGESTION_HASHES_KEY):
         existing_list = app_properties[SUGGESTION_HASHES_KEY].split(",")
         existing_set = set(existing_list)
@@ -187,7 +195,7 @@ def review_document(
 def post_comments(
     drive_service: Any,
     document_id: str,
-    items: List[Dict[str, str]],
+    items: list[dict[str, str]],
 ) -> None:
     """Post review items as comments on the document.
 
@@ -200,9 +208,9 @@ def post_comments(
 
     MAX_BYTES = 4096
 
-    def _chunk_content(text: str) -> List[str]:
+    def _chunk_content(text: str) -> list[str]:
         """Split ``text`` into <= ``MAX_BYTES`` byte chunks."""
-        chunks: List[str] = []
+        chunks: list[str] = []
         encoded = text.encode("utf-8")
         while encoded:
             piece = encoded[:MAX_BYTES]
@@ -214,7 +222,7 @@ def post_comments(
     document_text = download_revision_text(drive_service, document_id, "head")
 
     for item in items:
-        lines: List[str] = []
+        lines: list[str] = []
         issue = item.get("issue")
         if issue:
             lines.append(issue)


### PR DESCRIPTION
## Summary
- document review pipeline responsibilities at module top
- clarify `_hash` purpose for suggestion de-duplication
- replace deprecated `typing` generics with builtin `list`/`dict`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3d914b860832893c6c741e7e182e6