### PR TITLE
Add UTF-8 safe comment chunking and error handling

### DIFF
--- a/src/review.py
+++ b/src/review.py
@@ -133,6 +133,19 @@ def _prune_hashes(hashes: list[str], max_bytes: int = 124) -> str:
     return joined
 
 
+def split_into_byte_chunks(text: str, max_bytes: int) -> list[str]:
+    """Split ``text`` into UTF-8 safe chunks each no larger than ``max_bytes``."""
+
+    chunks: list[str] = []
+    encoded = text.encode("utf-8")
+    while encoded:
+        piece = encoded[:max_bytes]
+        chunk = piece.decode("utf-8", errors="ignore")
+        chunks.append(chunk)
+        encoded = encoded[len(chunk.encode("utf-8")) :]
+    return chunks
+
+
 def deduplicate_suggestions(
     items: list[dict[str, str]], existing_hashes: set[str]
 ) -> list[dict[str, str]]:
@@ -207,17 +220,6 @@ def post_comments(
     """
 
     MAX_BYTES = 4096
-
-    def _chunk_content(text: str) -> list[str]:
-        """Split ``text`` into <= ``MAX_BYTES`` byte chunks."""
-        chunks: list[str] = []
-        encoded = text.encode("utf-8")
-        while encoded:
-            piece = encoded[:MAX_BYTES]
-            chunk = piece.decode("utf-8", errors="ignore")
-            chunks.append(chunk)
-            encoded = encoded[len(chunk.encode("utf-8")) :]
-        return chunks
     # Retrieve plain text of the latest revision so we can derive line numbers
     document_text = download_revision_text(drive_service, document_id, "head")
 
@@ -228,7 +230,7 @@ def post_comments(
             lines.append(issue)
         lines.append(item.get("suggestion", ""))
         content = "\n".join(lines)
-        parts = _chunk_content(content)
+        parts = split_into_byte_chunks(content, MAX_BYTES)
         # Post the first part anchored to the text range
         start = item.get("start_index")
         end = item.get("end_index")
@@ -238,13 +240,24 @@ def post_comments(
             end_line = document_text.count("\n", 0, max(end - 1, 0)) + 1
             line_count = end_line - start_line + 1
             regions = [{"line": {"n": start_line, "l": line_count}}]
-        comment = create_comment(
-            drive_service,
-            document_id,
-            parts[0],
-            revision_id="head",
-            regions=regions,
-        )
+        try:
+            comment = create_comment(
+                drive_service,
+                document_id,
+                parts[0],
+                revision_id="head",
+                regions=regions,
+            )
+        except Exception:
+            logging.exception("Failed to create comment for %s", document_id)
+            continue
         # Post remaining parts as replies
         for part in parts[1:]:
-            reply_to_comment(drive_service, document_id, comment["id"], part)
+            try:
+                reply_to_comment(drive_service, document_id, comment["id"], part)
+            except Exception:
+                logging.exception(
+                    "Failed to reply to comment %s for %s",
+                    comment.get("id"),
+                    document_id,
+                )

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 from src.review import (
     _hash,
     _prune_hashes,
+    split_into_byte_chunks,
     deduplicate_suggestions,
     detect_changed_ranges,
     process_changed_ranges,
@@ -295,3 +296,11 @@ def test_suggestion_hashes_property_total_size_limit():
     value = update_body["appProperties"][SUGGESTION_HASHES_KEY]
     total = len(SUGGESTION_HASHES_KEY.encode("utf-8")) + len(value.encode("utf-8"))
     assert total <= 124
+
+
+def test_split_into_byte_chunks_utf8_boundary():
+    text = "😀" * 2000
+    max_bytes = 4096
+    chunks = split_into_byte_chunks(text, max_bytes)
+    assert all(len(chunk.encode("utf-8")) <= max_bytes for chunk in chunks)
+    assert "".join(chunks) == text


### PR DESCRIPTION
## Summary
- add `split_into_byte_chunks` to safely split comment content by bytes
- update comment posting to use helper and log failures when creating or replying to comments
- test UTF-8 chunking boundaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3dbecf0d4832889491c67e9ba1423