### PR TITLE
Use requests session with retry adapter

### DIFF
--- a/src/groq_client.py
+++ b/src/groq_client.py
@@ -9,11 +9,20 @@ import threading
 import random
 from collections import deque
 import requests
+from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError, RequestException
+from urllib3.util.retry import Retry
 
 from config import settings
 
 logger = logging.getLogger(__name__)
+
+# Shared requests session with a basic retry strategy for transient errors
+session = requests.Session()
+_retry = Retry(total=3, backoff_factor=0.3, allowed_methods=["POST"])
+adapter = HTTPAdapter(max_retries=_retry)
+session.mount("https://", adapter)
+session.mount("http://", adapter)
 
 # Groq's OpenAI-compatible endpoint for chat completions
 # https://console.groq.com/docs shows that the API mirrors OpenAI's
@@ -140,7 +149,7 @@ def _post_with_retry(
     for attempt in range(1, retries + 1):
         try:
             rate_limiter.acquire()
-            resp = requests.post(
+            resp = session.post(
                 GROQ_API_URL, json=payload, headers=headers, timeout=30
             )
             if resp.status_code >= 400:

--- a/test/test_groq_client.py
+++ b/test/test_groq_client.py
@@ -23,7 +23,7 @@ def test_get_suggestions_calls_api(monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("src.groq_client.session.post", fake_post)
     resp = get_suggestions("Some text")
     assert resp == {"choices": []}
     assert captured["url"] == GROQ_API_URL
@@ -60,7 +60,7 @@ def test_get_suggestions_retries_on_server_error(monkeypatch):
             return Resp(False)
         return Resp(True)
 
-    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("src.groq_client.session.post", fake_post)
     resp = get_suggestions("ok")
     assert resp == {"choices": []}
     assert calls["count"] == 2
@@ -72,7 +72,7 @@ def test_get_suggestions_raises_after_retries(monkeypatch):
 
         raise RequestException("boom")
 
-    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("src.groq_client.session.post", fake_post)
     with pytest.raises(Exception):
         get_suggestions("fail", retries=2, backoff=0)
 
@@ -103,7 +103,7 @@ def test_get_suggestions_chunks_large_text(monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("src.groq_client.session.post", fake_post)
     large_text = "x" * (CHUNK_SIZE * 2 + 10)
     resp = get_suggestions(large_text)
     assert calls["count"] == 3
@@ -133,7 +133,7 @@ def test_get_suggestions_retries_on_429(monkeypatch):
 
     sleeps: list[float] = []
 
-    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("src.groq_client.session.post", fake_post)
     monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
     monkeypatch.setattr("random.uniform", lambda a, b: 0)
     monkeypatch.setattr("src.groq_client.rate_limiter.acquire", lambda: None)
@@ -291,7 +291,7 @@ def test_get_suggestions_halts_on_persistent_429(monkeypatch, caplog):
 
         return Resp()
 
-    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("src.groq_client.session.post", fake_post)
     monkeypatch.setattr("src.groq_client.rate_limiter.acquire", lambda: None)
 
     text = "x" * (CHUNK_SIZE * 2)
@@ -352,7 +352,7 @@ def test_spacing_prevents_429(monkeypatch):
 
     monkeypatch.setattr(gc.time, "time", fake_time)
     monkeypatch.setattr(gc.time, "sleep", fake_sleep)
-    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("src.groq_client.session.post", fake_post)
     gc.rate_limiter = gc.RateLimiter(60)
 
     for _ in range(5):


### PR DESCRIPTION
## Summary
- add module-level requests session with small retry strategy
- swap direct requests.post calls for session.post
- adjust tests to patch the new session

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3e1ff81208328b036a3ec0f94c660