### PR TITLE
Handle head revision download via files export

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -87,14 +87,23 @@ def update_app_properties(
 
 def download_revision_text(service: Any, file_id: str, revision_id: str) -> str:
     """Download revision content as plain text."""
-    content = (
-        service.revisions()
-        .get(fileId=file_id, revisionId=revision_id, alt="media")
-        .execute(num_retries=3)
-    )
+    if revision_id == "head":
+        content = (
+            service.files()
+            .export(fileId=file_id, mimeType="text/plain")
+            .execute(num_retries=3)
+        )
+    else:
+        content = (
+            service.revisions()
+            .get(fileId=file_id, revisionId=revision_id, alt="media")
+            .execute(num_retries=3)
+        )
     if isinstance(content, bytes):
         return content.decode()
-    return content
+    if isinstance(content, str):
+        return content
+    return str(content)
 
 
 def get_share_message(service: Any, file_id: str) -> str:

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -118,6 +118,17 @@ def test_download_revision_text_decodes_bytes():
     assert text == "hello"
 
 
+def test_download_revision_head_uses_files_export():
+    service = MagicMock()
+    service.files.return_value.export.return_value.execute.return_value = b"hi"
+    text = download_revision_text(service, "f", "head")
+    assert text == "hi"
+    service.files.return_value.export.assert_called_once_with(
+        fileId="f", mimeType="text/plain"
+    )
+    service.revisions.return_value.get.assert_not_called()
+
+
 def test_get_share_message_fetches_description():
     service = MagicMock()
     service.files.return_value.get.return_value.execute.return_value = {


### PR DESCRIPTION
## Summary
- Support `revision_id="head"` in `download_revision_text` by exporting the file
- Ensure revision downloads return strings
- Test `download_revision_text` for `head` export

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a48831ebc083288356906f6a7fb229