### PR TITLE
refactor: broaden Drive doc query

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -36,7 +36,7 @@ def list_recent_docs(service: Any, since_time: datetime) -> list[dict[str, Any]]
     iso_time = since_time.replace(microsecond=0).isoformat("T") + "Z"
     query = (
         "mimeType='application/vnd.google-apps.document' "
-        f"and (modifiedTime > '{iso_time}' or sharedWithMe = true)"
+        f"and (modifiedTime > '{iso_time}' or sharedWithMe)"
     )
 
     files: list[dict[str, Any]] = []
@@ -47,7 +47,7 @@ def list_recent_docs(service: Any, since_time: datetime) -> list[dict[str, Any]]
             "fields": "nextPageToken, files(id, name, modifiedTime, sharedWithMeTime)",
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
-            "corpora": "allDrives",
+            "corpora": "user",
             "pageSize": 1000,
         }
         if page_token:

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -31,14 +31,14 @@ def test_list_recent_docs_filters_by_time():
     iso_time = since.replace(microsecond=0).isoformat("T") + "Z"
     expected_query = (
         "mimeType='application/vnd.google-apps.document' "
-        f"and (modifiedTime > '{iso_time}' or sharedWithMe = true)"
+        f"and (modifiedTime > '{iso_time}' or sharedWithMe)"
     )
     service.files.return_value.list.assert_called_once_with(
         q=expected_query,
         fields="nextPageToken, files(id, name, modifiedTime, sharedWithMeTime)",
         supportsAllDrives=True,
         includeItemsFromAllDrives=True,
-        corpora="allDrives",
+        corpora="user",
         pageSize=1000,
     )
     assert files[0]["name"] == "Doc1"
@@ -62,14 +62,14 @@ def test_list_recent_docs_includes_newly_shared_docs():
     iso_time = since.isoformat("T") + "Z"
     expected_query = (
         "mimeType='application/vnd.google-apps.document' "
-        f"and (modifiedTime > '{iso_time}' or sharedWithMe = true)"
+        f"and (modifiedTime > '{iso_time}' or sharedWithMe)"
     )
     service.files.return_value.list.assert_called_once_with(
         q=expected_query,
         fields="nextPageToken, files(id, name, modifiedTime, sharedWithMeTime)",
         supportsAllDrives=True,
         includeItemsFromAllDrives=True,
-        corpora="allDrives",
+        corpora="user",
         pageSize=1000,
     )
     assert files[0]["name"] == "Shared"


### PR DESCRIPTION
## Summary
- search for shared documents using `or sharedWithMe`
- scope Drive listing to the user corpus
- align tests with updated query parameters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a48e8af6488328896053de195059fd