### PR TITLE
Fix detection of newly shared Google Docs

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -1,7 +1,7 @@
 """Google Drive API utilities."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 from .google_service import build_service
@@ -53,7 +53,7 @@ def list_recent_docs(service: Any, since_time: datetime) -> list[dict[str, Any]]
     while True:
         params = {
             "q": modified_query,
-            "fields": "nextPageToken, files(id, name, modifiedTime, createdTime)",
+            "fields": "nextPageToken, files(id, name, modifiedTime, createdTime, sharedWithMeTime)",
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
             "corpora": "allDrives",
@@ -67,17 +67,15 @@ def list_recent_docs(service: Any, since_time: datetime) -> list[dict[str, Any]]
         if not page_token:
             break
 
-    # Get all accessible documents to find newly shared ones
-    # We limit this to recent createdTime to avoid processing too many old documents
-    recent_created_time = (since_time - timedelta(days=30)).replace(microsecond=0).isoformat("T") + "Z"
-    all_query_with_limit = f"{all_query} and createdTime > '{recent_created_time}'"
-    
+    # Get all accessible documents to find newly shared ones.
+    # We can't reliably filter by ``sharedWithMeTime`` using Drive queries for
+    # service accounts, so we request all accessible Docs and filter locally.
     page_token = None
     all_files: list[dict[str, Any]] = []
     while True:
         params = {
-            "q": all_query_with_limit,
-            "fields": "nextPageToken, files(id, name, modifiedTime, createdTime)",
+            "q": all_query,
+            "fields": "nextPageToken, files(id, name, modifiedTime, createdTime, sharedWithMeTime)",
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
             "corpora": "allDrives",
@@ -95,21 +93,27 @@ def list_recent_docs(service: Any, since_time: datetime) -> list[dict[str, Any]]
     files_by_id = {f["id"]: f for f in files}
     for f in all_files:
         if f["id"] not in files_by_id:
-            # This is a newly accessible document - check if it's actually "new"
-            # by seeing if it was created recently or if we haven't seen it before
-            created_time = f.get("createdTime")
-            if created_time:
+            # This is a newly accessible document - include it if it was
+            # recently created or recently shared with the service account.
+            include = False
+            for key in ("sharedWithMeTime", "createdTime"):
+                ts = f.get(key)
+                if not ts:
+                    continue
                 try:
-                    created_dt = parse_google_timestamp(created_time)
-                    if created_dt > since_time:
-                        files_by_id[f["id"]] = f
+                    dt = parse_google_timestamp(ts)
                 except ValueError:
-                    pass
+                    continue
+                if dt > since_time:
+                    include = True
+                    break
+            if include:
+                files_by_id[f["id"]] = f
 
     recent_files: list[dict[str, Any]] = []
     for f in files_by_id.values():
-        # Include if recently modified or recently created
-        for key in ("modifiedTime", "createdTime"):
+        # Include if recently modified, created, or shared
+        for key in ("modifiedTime", "createdTime", "sharedWithMeTime"):
             ts = f.get(key)
             if not ts:
                 continue

--- a/src/main.py
+++ b/src/main.py
@@ -101,12 +101,12 @@ def _process_document(
 def _latest_timestamp(file: dict[str, Any], current: datetime) -> datetime:
     """Return the latest relevant timestamp for ``file``.
 
-    Considers both ``modifiedTime`` and ``createdTime`` and returns the
-    newer one, falling back to ``current`` when parsing fails or timestamps are
-    missing.
+    Considers ``modifiedTime``, ``createdTime`` and ``sharedWithMeTime`` and
+    returns the newest one, falling back to ``current`` when parsing fails or
+    timestamps are missing.
     """
 
-    for key in ("modifiedTime", "createdTime"):
+    for key in ("modifiedTime", "createdTime", "sharedWithMeTime"):
         ts = file.get(key)
         if not ts:
             continue

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -38,11 +38,11 @@ def test_list_recent_docs_filters_by_time():
 
 
 def test_list_recent_docs_includes_newly_shared_docs():
-    """Documents shared but not modified should still be returned via creation time."""
+    """Docs shared recently should be returned even if created long ago."""
     service = MagicMock()
-    
+
     # First call returns empty (no recently modified docs)
-    # Second call returns the newly accessible doc
+    # Second call returns a document that was created earlier but shared now
     service.files.return_value.list.return_value.execute.side_effect = [
         {"files": []},  # No recently modified docs
         {
@@ -50,17 +50,18 @@ def test_list_recent_docs_includes_newly_shared_docs():
                 {
                     "id": "1",
                     "name": "Shared",
-                    "modifiedTime": "2024-01-01T00:00:00Z",
-                    "createdTime": "2024-01-02T00:00:00Z",  # Recently created
+                    "modifiedTime": "2023-01-01T00:00:00Z",
+                    "createdTime": "2023-01-02T00:00:00Z",
+                    "sharedWithMeTime": "2024-01-02T00:00:00Z",  # Newly shared
                 }
             ]
-        },  # Newly accessible doc
+        },
     ]
-    
+
     since = datetime(2024, 1, 1, 12, 0, 0)
     files = list_recent_docs(service, since)
-    
-    # Should make two calls: one for recently modified, one for all recent docs
+
+    # Should make two calls: one for recently modified, one for all docs
     assert service.files.return_value.list.call_count == 2
     assert files[0]["name"] == "Shared"
 

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -78,7 +78,7 @@ def test_latest_timestamp():
     since = datetime(2020, 1, 1)
     file = {
         "modifiedTime": "2021-02-01T00:00:00Z",
-        "sharedWithMeTime": "2020-06-01T00:00:00Z",
+        "sharedWithMeTime": "2022-06-01T00:00:00Z",
     }
 
-    assert _latest_timestamp(file, since) == datetime(2021, 2, 1)
+    assert _latest_timestamp(file, since) == datetime(2022, 6, 1)


### PR DESCRIPTION
## Summary
- Capture `sharedWithMeTime` when polling Drive to catch documents recently shared with the service account
- Consider `sharedWithMeTime` when calculating the newest timestamp for the next run
- Test newly shared doc detection and latest timestamp computation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a667a4a05483288df976449e9798df