### PR TITLE
Use Drive changes feed to detect newly shared docs

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -17,13 +17,46 @@ def build_drive_service() -> Any:
     return build_service("drive", "v3", SCOPES)
 
 
-def list_recent_docs(service: Any, since_time: datetime) -> list[dict[str, Any]]:
-    """Return Google Docs accessible to the service account, recently modified or accessed.
+def list_recent_changes(
+    service: Any, page_token: str
+) -> tuple[list[dict[str, Any]], str]:
+    """Return files whose metadata or permissions changed since ``page_token``.
 
-    For service accounts, the 'sharedWithMe' query parameter doesn't work as it does
-    for regular user accounts. Instead, we query all accessible Google Docs and 
-    filter by modification time, then separately query recently accessible documents
-    to catch newly shared ones.
+    Parameters
+    ----------
+    service
+        Authenticated Google Drive service instance.
+    page_token
+        Change page token retrieved from ``changes().getStartPageToken``.
+    """
+
+    files: list[dict[str, Any]] = []
+    token = page_token
+    while True:
+        params = {
+            "pageToken": token,
+            "fields": (
+                "nextPageToken,newStartPageToken,"
+                "changes(file(id,name,mimeType,modifiedTime,createdTime,sharedWithMeTime))"
+            ),
+            "supportsAllDrives": True,
+            "includeItemsFromAllDrives": True,
+            "pageSize": 1000,
+        }
+        results = service.changes().list(**params).execute(num_retries=3)
+        for change in results.get("changes", []):
+            file = change.get("file")
+            if file and file.get("mimeType") == "application/vnd.google-apps.document":
+                files.append(file)
+        token = results.get("nextPageToken")
+        if not token:
+            return files, results.get("newStartPageToken", page_token)
+
+
+def list_recent_docs(
+    service: Any, since_time: datetime, page_token: str
+) -> tuple[list[dict[str, Any]], str]:
+    """Return Google Docs changed or shared since ``since_time`` and ``page_token``.
 
     Parameters
     ----------
@@ -31,72 +64,61 @@ def list_recent_docs(service: Any, since_time: datetime) -> list[dict[str, Any]]
         Authenticated Google Drive service instance.
     since_time
         ``datetime`` of the last run. Documents with ``modifiedTime`` after this
-        timestamp or that are newly accessible are returned.
+        timestamp are returned.
+    page_token
+        Change page token from the previous run used to query the changes feed.
     """
 
     iso_time = since_time.replace(microsecond=0).isoformat("T") + "Z"
-    
-    # Query 1: Recently modified documents
+
     modified_query = (
         "mimeType='application/vnd.google-apps.document' "
         f"and modifiedTime > '{iso_time}'"
     )
-    
-    # Query 2: All accessible documents (to catch newly shared ones)
-    # We'll compare against known documents to find new ones
-    all_query = "mimeType='application/vnd.google-apps.document'"
 
     files: list[dict[str, Any]] = []
-    
-    # Get recently modified documents
-    page_token: str | None = None
+
+    # Fetch recently modified docs
+    file_page: str | None = None
     while True:
         params = {
             "q": modified_query,
-            "fields": "nextPageToken, files(id, name, modifiedTime, createdTime, sharedWithMeTime)",
+            "fields": (
+                "nextPageToken, files(id,name,modifiedTime,createdTime,sharedWithMeTime)"
+            ),
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
             "corpora": "allDrives",
             "pageSize": 1000,
         }
-        if page_token:
-            params["pageToken"] = page_token
+        if file_page:
+            params["pageToken"] = file_page
         results = service.files().list(**params).execute(num_retries=3)
         files.extend(results.get("files", []))
-        page_token = results.get("nextPageToken")
-        if not page_token:
+        file_page = results.get("nextPageToken")
+        if not file_page:
             break
 
-    # Get all accessible documents to find newly shared ones.
-    # We can't reliably filter by ``sharedWithMeTime`` using Drive queries for
-    # service accounts, so we request all accessible Docs and filter locally.
-    page_token = None
-    all_files: list[dict[str, Any]] = []
-    while True:
-        params = {
-            "q": all_query,
-            "fields": "nextPageToken, files(id, name, modifiedTime, createdTime, sharedWithMeTime)",
-            "supportsAllDrives": True,
-            "includeItemsFromAllDrives": True,
-            "corpora": "allDrives",
-            "pageSize": 1000,
-        }
-        if page_token:
-            params["pageToken"] = page_token
-        results = service.files().list(**params).execute(num_retries=3)
-        all_files.extend(results.get("files", []))
-        page_token = results.get("nextPageToken")
-        if not page_token:
-            break
+    # Fetch changes to catch newly shared docs
+    change_files, new_page_token = list_recent_changes(service, page_token)
 
-    # Combine results and deduplicate by file ID
     files_by_id = {f["id"]: f for f in files}
-    for f in all_files:
-        if f["id"] not in files_by_id:
-            # This is a newly accessible document - include it if it was
-            # recently created or recently shared with the service account.
-            include = False
-            for key in ("sharedWithMeTime", "createdTime"):
+    for f in change_files:
+        fid = f.get("id")
+        if not fid:
+            continue
+        f["_include_unconditionally"] = True
+        if fid not in files_by_id:
+            files_by_id[fid] = f
+        else:
+            files_by_id[fid].update(f)
+            files_by_id[fid]["_include_unconditionally"] = True
+
+    recent_files: list[dict[str, Any]] = []
+    for f in files_by_id.values():
+        include = f.pop("_include_unconditionally", False)
+        if not include:
+            for key in ("modifiedTime", "createdTime", "sharedWithMeTime"):
                 ts = f.get(key)
                 if not ts:
                     continue
@@ -107,25 +129,10 @@ def list_recent_docs(service: Any, since_time: datetime) -> list[dict[str, Any]]
                 if dt > since_time:
                     include = True
                     break
-            if include:
-                files_by_id[f["id"]] = f
+        if include:
+            recent_files.append(f)
 
-    recent_files: list[dict[str, Any]] = []
-    for f in files_by_id.values():
-        # Include if recently modified, created, or shared
-        for key in ("modifiedTime", "createdTime", "sharedWithMeTime"):
-            ts = f.get(key)
-            if not ts:
-                continue
-            try:
-                dt = parse_google_timestamp(ts)
-            except ValueError:
-                continue
-            if dt > since_time:
-                recent_files.append(f)
-                break
-    
-    return recent_files
+    return recent_files, new_page_token
 
 
 def get_app_properties(service: Any, file_id: str) -> tuple[dict[str, str], str]:

--- a/src/main.py
+++ b/src/main.py
@@ -120,24 +120,27 @@ def _latest_timestamp(file: dict[str, Any], current: datetime) -> datetime:
 
 
 def run_once(
-    drive_service: Any, docs_service: Any, since: datetime
-) -> datetime:
-    """Process documents changed since ``since`` and return new timestamp.
+    drive_service: Any, docs_service: Any, since: datetime, page_token: str
+) -> tuple[datetime, str]:
+    """Process documents changed since ``since`` and return new timestamp and token.
 
     Documents are considered changed if they were modified or newly shared with
-    the service account after the provided ``since`` timestamp.
+    the service account after the provided ``since`` timestamp. ``page_token`` is
+    used to query the Drive changes feed for permission updates.
     """
 
     logger.info(
-        "Starting document review cycle. Checking for documents changed since: %s", since
+        "Starting document review cycle. Checking for documents changed since: %s",
+        since,
     )
 
     try:
-        files = list_recent_docs(drive_service, since)
+        files, new_page_token = list_recent_docs(drive_service, since, page_token)
         logger.info("Found %d documents to process", len(files))
     except Exception as e:  # pragma: no cover - logging path
         logger.error(f"Error during document review cycle: {e}")
         files = []
+        new_page_token = page_token
 
     processed_count = 0
     latest_time = since
@@ -154,9 +157,10 @@ def run_once(
 
     new_timestamp = max(latest_time, datetime.utcnow())
     logger.info(
-        "Next review cycle will check for documents changed after: %s", new_timestamp
+        "Next review cycle will check for documents changed after: %s",
+        new_timestamp,
     )
-    return new_timestamp
+    return new_timestamp, new_page_token
 
 
 def main() -> None:
@@ -174,14 +178,21 @@ def main() -> None:
 
         since = datetime.utcnow()
         logger.info(f"Initial timestamp set to: {since}")
+        page_token = (
+            drive_service.changes()
+            .getStartPageToken(supportsAllDrives=True)
+            .execute()
+            .get("startPageToken", "")
+        )
+        logger.info(f"Initial change token set to: {page_token}")
         
         import schedule
         
         def job() -> None:
-            nonlocal since
+            nonlocal since, page_token
             logger.info("=" * 60)
             logger.info("Scheduled job triggered - starting document review")
-            since = run_once(drive_service, docs_service, since)
+            since, page_token = run_once(drive_service, docs_service, since, page_token)
             logger.info("Scheduled job completed")
             logger.info("=" * 60)
         

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -21,114 +21,156 @@ from src.google_drive import (
 
 def test_list_recent_docs_filters_by_time():
     service = MagicMock()
-    service.files.return_value.list.return_value.execute.side_effect = [
-        {
-            "files": [
-                {"id": "1", "name": "Doc1", "modifiedTime": "2024-01-01T00:00:00Z"}
-            ]
-        },  # Recently modified docs
-        {"files": []},  # No additional accessible docs
-    ]
+    service.files.return_value.list.return_value.execute.return_value = {
+        "files": [
+            {"id": "1", "name": "Doc1", "modifiedTime": "2024-01-01T00:00:00Z"}
+        ]
+    }
+    service.changes.return_value.list.return_value.execute.return_value = {
+        "changes": [],
+        "newStartPageToken": "t1",
+    }
+
     since = datetime(2023, 12, 31, 23, 0, 0)
-    files = list_recent_docs(service, since)
-    
-    # Should make two calls now
-    assert service.files.return_value.list.call_count == 2
+    files, token = list_recent_docs(service, since, "t0")
+
+    assert service.files.return_value.list.call_count == 1
+    assert service.changes.return_value.list.call_count == 1
     assert files[0]["name"] == "Doc1"
+    assert token == "t1"
 
 
 def test_list_recent_docs_includes_newly_shared_docs():
     """Docs shared recently should be returned even if created long ago."""
     service = MagicMock()
 
-    # First call returns empty (no recently modified docs)
-    # Second call returns a document that was created earlier but shared now
-    service.files.return_value.list.return_value.execute.side_effect = [
-        {"files": []},  # No recently modified docs
-        {
-            "files": [
-                {
+    service.files.return_value.list.return_value.execute.return_value = {"files": []}
+    service.changes.return_value.list.return_value.execute.return_value = {
+        "changes": [
+            {
+                "file": {
                     "id": "1",
                     "name": "Shared",
+                    "mimeType": "application/vnd.google-apps.document",
                     "modifiedTime": "2023-01-01T00:00:00Z",
                     "createdTime": "2023-01-02T00:00:00Z",
-                    "sharedWithMeTime": "2024-01-02T00:00:00Z",  # Newly shared
+                    "sharedWithMeTime": "2024-01-02T00:00:00Z",
                 }
-            ]
-        },
-    ]
+            }
+        ],
+        "newStartPageToken": "t1",
+    }
 
     since = datetime(2024, 1, 1, 12, 0, 0)
-    files = list_recent_docs(service, since)
+    files, _ = list_recent_docs(service, since, "t0")
 
-    # Should make two calls: one for recently modified, one for all docs
-    assert service.files.return_value.list.call_count == 2
+    assert service.files.return_value.list.call_count == 1
+    assert service.changes.return_value.list.call_count == 1
     assert files[0]["name"] == "Shared"
 
 
 def test_list_recent_docs_parses_microsecond_timestamps():
     """Timestamps with fractional seconds should be parsed correctly."""
     service = MagicMock()
-    service.files.return_value.list.return_value.execute.side_effect = [
-        {
-            "files": [
-                {
-                    "id": "1",
-                    "name": "Micro",
-                    "modifiedTime": "2024-01-02T00:00:00.123456Z",
-                }
-            ]
-        },  # Recently modified docs
-        {
-            "files": [
-                {
+    service.files.return_value.list.return_value.execute.return_value = {
+        "files": [
+            {
+                "id": "1",
+                "name": "Micro",
+                "modifiedTime": "2024-01-02T00:00:00.123456Z",
+            }
+        ]
+    }
+    service.changes.return_value.list.return_value.execute.return_value = {
+        "changes": [
+            {
+                "file": {
                     "id": "2",
                     "name": "CreatedMicro",
+                    "mimeType": "application/vnd.google-apps.document",
                     "createdTime": "2024-01-02T00:00:00.654321Z",
                     "modifiedTime": "2024-01-01T00:00:00Z",
                 }
-            ]
-        },  # Recently created/accessible docs
-    ]
+            }
+        ],
+        "newStartPageToken": "t1",
+    }
     since = datetime(2024, 1, 1, 23, 59, 59)
-    files = list_recent_docs(service, since)
+    files, _ = list_recent_docs(service, since, "t0")
     assert {f["name"] for f in files} == {"Micro", "CreatedMicro"}
 
 
 def test_list_recent_docs_handles_pagination():
     service = MagicMock()
-    # Mock responses for the two different queries
-    first_query_pages = [{"files": [], "nextPageToken": "t1"}, {"files": []}]
-    second_query_pages = [
-        {"files": [], "nextPageToken": "t2"},
+    # Pages for modified docs query
+    file_pages = [{"files": [], "nextPageToken": "t1"}, {"files": []}]
+    # Pages for changes feed
+    change_pages = [
+        {"changes": [], "nextPageToken": "c1"},
         {
-            "files": [
+            "changes": [
                 {
-                    "id": "new",
-                    "name": "NewDoc",
-                    "createdTime": "2024-01-02T00:00:00Z",
-                    "modifiedTime": "2024-01-01T00:00:00Z",
+                    "file": {
+                        "id": "new",
+                        "name": "NewDoc",
+                        "mimeType": "application/vnd.google-apps.document",
+                        "createdTime": "2024-01-02T00:00:00Z",
+                        "modifiedTime": "2024-01-01T00:00:00Z",
+                    }
                 }
-            ]
+            ],
+            "newStartPageToken": "c2",
         },
     ]
-    
-    service.files.return_value.list.return_value.execute.side_effect = (
-        first_query_pages + second_query_pages
-    )
-    
+
+    service.files.return_value.list.return_value.execute.side_effect = file_pages
+    service.changes.return_value.list.return_value.execute.side_effect = change_pages
+
     since = datetime(2024, 1, 1, 12, 0, 0)
-    files = list_recent_docs(service, since)
+    files, token = list_recent_docs(service, since, "c0")
     assert files == [
         {
             "id": "new",
             "name": "NewDoc",
+            "mimeType": "application/vnd.google-apps.document",
             "createdTime": "2024-01-02T00:00:00Z",
             "modifiedTime": "2024-01-01T00:00:00Z",
         }
     ]
-    # Should make 4 calls total (2 pages for each of 2 queries)
-    assert service.files.return_value.list.call_count == 4
+    assert token == "c2"
+    assert service.files.return_value.list.call_count == 2
+    assert service.changes.return_value.list.call_count == 2
+
+
+def test_list_recent_docs_detects_permission_changes_without_shared_time():
+    service = MagicMock()
+    service.files.return_value.list.return_value.execute.return_value = {"files": []}
+    service.changes.return_value.list.return_value.execute.return_value = {
+        "changes": [
+            {
+                "file": {
+                    "id": "1",
+                    "name": "NoSharedTime",
+                    "mimeType": "application/vnd.google-apps.document",
+                    "modifiedTime": "2020-01-01T00:00:00Z",
+                    "createdTime": "2020-01-01T00:00:00Z",
+                }
+            }
+        ],
+        "newStartPageToken": "t1",
+    }
+
+    since = datetime(2024, 1, 1, 0, 0, 0)
+    files, _ = list_recent_docs(service, since, "t0")
+    assert files == [
+        {
+            "id": "1",
+            "name": "NoSharedTime",
+            "mimeType": "application/vnd.google-apps.document",
+            "modifiedTime": "2020-01-01T00:00:00Z",
+            "createdTime": "2020-01-01T00:00:00Z",
+        }
+    ]
 
 
 def test_app_properties_roundtrip():

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -8,7 +8,8 @@ def test_run_once_reviews_and_posts(monkeypatch):
     drive = MagicMock()
     docs = MagicMock()
     monkeypatch.setattr(
-        "src.main.list_recent_docs", lambda svc, since: [{"id": "1"}, {"id": "2"}]
+        "src.main.list_recent_docs",
+        lambda svc, since, token: ([{"id": "1"}, {"id": "2"}], token),
     )
 
     reviews = [
@@ -29,13 +30,14 @@ def test_run_once_reviews_and_posts(monkeypatch):
     monkeypatch.setattr("src.main.post_comments", fake_post)
 
     since = datetime.utcnow()
-    new_since = run_once(drive, docs, since)
+    new_since, new_token = run_once(drive, docs, since, "t0")
 
     assert posted == [(
         "1",
         [{"suggestion": "s1", "hash": "h1", "start_index": 0, "end_index": 1}],
     )]
     assert isinstance(new_since, datetime) and new_since >= since
+    assert new_token == "t0"
 
 
 def test_process_document_success(monkeypatch):


### PR DESCRIPTION
## Summary
- add `list_recent_changes` helper leveraging Drive API changes feed
- integrate changes feed into `list_recent_docs` and propagate change token
- make runner maintain change page token between cycles
- test change feed handling for docs lacking `sharedWithMeTime`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a675bc8d548328afd899c4a953defc