### PR TITLE
Filter Drive changes for service account

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -19,6 +19,16 @@ def build_drive_service() -> Any:
     return build_service("drive", "v3", SCOPES)
 
 
+def _get_permission_id(service: Any) -> str:
+    """Return the Drive permission ID for the authenticated service account."""
+    about = (
+        service.about()
+        .get(fields="user(permissionId)")
+        .execute(num_retries=3)
+    )
+    return about.get("user", {}).get("permissionId", "")
+
+
 def list_recent_changes(
     service: Any, page_token: str
 ) -> tuple[list[dict[str, Any]], str]:
@@ -40,7 +50,8 @@ def list_recent_changes(
             "pageToken": token,
             "fields": (
                 "nextPageToken,newStartPageToken,"
-                "changes(file(id,name,mimeType,modifiedTime,createdTime,sharedWithMeTime))"
+                "changes(removed,file(id,name,mimeType,modifiedTime,createdTime,"
+                "sharedWithMeTime,permissionIds))"
             ),
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
@@ -54,6 +65,8 @@ def list_recent_changes(
             results.get("nextPageToken"),
         )
         for change in changes:
+            if change.get("removed"):
+                continue
             file = change.get("file")
             if file and file.get("mimeType") == "application/vnd.google-apps.document":
                 files.append(file)
@@ -125,15 +138,21 @@ def list_recent_docs(
     logger.info("Total %d docs from modifiedTime query", len(files))
 
     # Fetch changes to catch newly shared docs
+    permission_id = _get_permission_id(service)
     change_files, new_page_token = list_recent_changes(service, page_token)
+    change_files_filtered: list[dict[str, Any]] = []
+    for f in change_files:
+        if permission_id in f.get("permissionIds", []):
+            f.pop("permissionIds", None)
+            change_files_filtered.append(f)
     logger.info(
-        "Change feed returned %d docs; new change token %s",
-        len(change_files),
+        "Change feed returned %d docs after filtering; new change token %s",
+        len(change_files_filtered),
         new_page_token,
     )
 
     files_by_id = {f["id"]: f for f in files}
-    for f in change_files:
+    for f in change_files_filtered:
         fid = f.get("id")
         if not fid:
             continue

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -21,6 +21,9 @@ from src.google_drive import (
 
 def test_list_recent_docs_filters_by_time():
     service = MagicMock()
+    service.about.return_value.get.return_value.execute.return_value = {
+        "user": {"permissionId": "pid"}
+    }
     service.files.return_value.list.return_value.execute.return_value = {
         "files": [
             {"id": "1", "name": "Doc1", "modifiedTime": "2024-01-01T00:00:00Z"}
@@ -43,7 +46,10 @@ def test_list_recent_docs_filters_by_time():
 def test_list_recent_docs_includes_newly_shared_docs():
     """Docs shared recently should be returned even if created long ago."""
     service = MagicMock()
-
+    service.about.return_value.get.return_value.execute.return_value = {
+        "user": {"permissionId": "pid"}
+    }
+    
     service.files.return_value.list.return_value.execute.return_value = {"files": []}
     service.changes.return_value.list.return_value.execute.return_value = {
         "changes": [
@@ -55,6 +61,7 @@ def test_list_recent_docs_includes_newly_shared_docs():
                     "modifiedTime": "2023-01-01T00:00:00Z",
                     "createdTime": "2023-01-02T00:00:00Z",
                     "sharedWithMeTime": "2024-01-02T00:00:00Z",
+                    "permissionIds": ["pid"],
                 }
             }
         ],
@@ -72,6 +79,9 @@ def test_list_recent_docs_includes_newly_shared_docs():
 def test_list_recent_docs_parses_microsecond_timestamps():
     """Timestamps with fractional seconds should be parsed correctly."""
     service = MagicMock()
+    service.about.return_value.get.return_value.execute.return_value = {
+        "user": {"permissionId": "pid"}
+    }
     service.files.return_value.list.return_value.execute.return_value = {
         "files": [
             {
@@ -90,6 +100,7 @@ def test_list_recent_docs_parses_microsecond_timestamps():
                     "mimeType": "application/vnd.google-apps.document",
                     "createdTime": "2024-01-02T00:00:00.654321Z",
                     "modifiedTime": "2024-01-01T00:00:00Z",
+                    "permissionIds": ["pid"],
                 }
             }
         ],
@@ -102,6 +113,9 @@ def test_list_recent_docs_parses_microsecond_timestamps():
 
 def test_list_recent_docs_handles_pagination():
     service = MagicMock()
+    service.about.return_value.get.return_value.execute.return_value = {
+        "user": {"permissionId": "pid"}
+    }
     # Pages for modified docs query
     file_pages = [{"files": [], "nextPageToken": "t1"}, {"files": []}]
     # Pages for changes feed
@@ -116,6 +130,7 @@ def test_list_recent_docs_handles_pagination():
                         "mimeType": "application/vnd.google-apps.document",
                         "createdTime": "2024-01-02T00:00:00Z",
                         "modifiedTime": "2024-01-01T00:00:00Z",
+                        "permissionIds": ["pid"],
                     }
                 }
             ],
@@ -144,6 +159,9 @@ def test_list_recent_docs_handles_pagination():
 
 def test_list_recent_docs_detects_permission_changes_without_shared_time():
     service = MagicMock()
+    service.about.return_value.get.return_value.execute.return_value = {
+        "user": {"permissionId": "pid"}
+    }
     service.files.return_value.list.return_value.execute.return_value = {"files": []}
     service.changes.return_value.list.return_value.execute.return_value = {
         "changes": [
@@ -154,6 +172,7 @@ def test_list_recent_docs_detects_permission_changes_without_shared_time():
                     "mimeType": "application/vnd.google-apps.document",
                     "modifiedTime": "2020-01-01T00:00:00Z",
                     "createdTime": "2020-01-01T00:00:00Z",
+                    "permissionIds": ["pid"],
                 }
             }
         ],
@@ -171,6 +190,31 @@ def test_list_recent_docs_detects_permission_changes_without_shared_time():
             "createdTime": "2020-01-01T00:00:00Z",
         }
     ]
+
+
+def test_list_recent_docs_skips_changes_without_service_permission():
+    service = MagicMock()
+    service.about.return_value.get.return_value.execute.return_value = {
+        "user": {"permissionId": "pid"}
+    }
+    service.files.return_value.list.return_value.execute.return_value = {"files": []}
+    service.changes.return_value.list.return_value.execute.return_value = {
+        "changes": [
+            {
+                "file": {
+                    "id": "1",
+                    "name": "Other",
+                    "mimeType": "application/vnd.google-apps.document",
+                    "permissionIds": ["other"],
+                }
+            }
+        ],
+        "newStartPageToken": "t1",
+    }
+    since = datetime(2024, 1, 1)
+    files, token = list_recent_docs(service, since, "t0")
+    assert files == []
+    assert token == "t1"
 
 
 def test_app_properties_roundtrip():


### PR DESCRIPTION
## Summary
- ensure Drive change polling only includes files that grant access to the service account
- support detection of re-shared documents by filtering change feed with the service account's permission ID
- add tests for permission-based filtering and for ignoring unrelated changes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6829c2a788328af2b468a5edc4a0f