### PR TITLE
Process pre-shared Google Docs before startup

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -29,6 +29,48 @@ def _get_permission_id(service: Any) -> str:
     return about.get("user", {}).get("permissionId", "")
 
 
+def list_all_shared_docs(service: Any) -> list[dict[str, Any]]:
+    """Return all Google Docs currently shared with the service account.
+
+    Parameters
+    ----------
+    service
+        Authenticated Google Drive service instance.
+    """
+
+    logger.info("Listing all shared Google Docs")
+    query = "mimeType='application/vnd.google-apps.document' and sharedWithMe"
+    files: list[dict[str, Any]] = []
+    page: str | None = None
+    while True:
+        params = {
+            "q": query,
+            "fields": (
+                "nextPageToken, files(id,name,modifiedTime,createdTime,sharedWithMeTime)"
+            ),
+            "supportsAllDrives": True,
+            "includeItemsFromAllDrives": True,
+            "corpora": "allDrives",
+            "pageSize": 1000,
+        }
+        if page:
+            params["pageToken"] = page
+        results = service.files().list(**params).execute(num_retries=3)
+        batch = results.get("files", [])
+        files.extend(batch)
+        logger.info(
+            "Retrieved %d shared docs (nextPageToken=%s)",
+            len(batch),
+            results.get("nextPageToken"),
+        )
+        page = results.get("nextPageToken")
+        if not page:
+            break
+
+    logger.info("Total %d shared docs retrieved", len(files))
+    return files
+
+
 def list_recent_changes(
     service: Any, page_token: str
 ) -> tuple[list[dict[str, Any]], str]:

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ import logging
 import time
 from typing import Any
 
-from .google_drive import build_drive_service, list_recent_docs
+from .google_drive import build_drive_service, list_recent_docs, list_all_shared_docs
 from .google_docs import build_docs_service
 from .groq_client import get_suggestions
 from .time_utils import parse_google_timestamp
@@ -180,6 +180,12 @@ def main() -> None:
         logger.info("Initializing Google Docs service...")
         docs_service = build_docs_service()
         logger.info("Google Docs service initialized successfully")
+
+        logger.info("Processing documents already shared with the service account...")
+        shared_docs = list_all_shared_docs(drive_service)
+        for f in shared_docs:
+            _process_document(drive_service, docs_service, f)
+        logger.info("Processed %d pre-existing shared documents", len(shared_docs))
 
         since = datetime.utcnow()
         logger.info(f"Initial timestamp set to: {since}")

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -10,6 +10,7 @@ from src.google_drive import (
     get_share_message,
     get_app_properties,
     list_recent_docs,
+    list_all_shared_docs,
     reply_to_comment,
     update_app_properties,
     build_drive_service,
@@ -17,6 +18,17 @@ from src.google_drive import (
     list_replies,
     create_comment,
 )
+
+
+def test_list_all_shared_docs_handles_pagination():
+    service = MagicMock()
+    service.files.return_value.list.return_value.execute.side_effect = [
+        {"files": [{"id": "1"}], "nextPageToken": "t1"},
+        {"files": [{"id": "2"}]},
+    ]
+    docs = list_all_shared_docs(service)
+    assert docs == [{"id": "1"}, {"id": "2"}]
+    assert service.files.return_value.list.call_count == 2
 
 
 def test_list_recent_docs_filters_by_time():

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 from src.main import run_once, _process_document, _latest_timestamp
+import src.main as runner
 
 
 def test_run_once_reviews_and_posts(monkeypatch):
@@ -84,3 +85,49 @@ def test_latest_timestamp():
     }
 
     assert _latest_timestamp(file, since) == datetime(2022, 6, 1)
+
+
+def test_main_processes_pre_shared_docs(monkeypatch):
+    drive = MagicMock()
+    drive.changes.return_value.getStartPageToken.return_value.execute.return_value = {
+        "startPageToken": "t0"
+    }
+    docs = MagicMock()
+    monkeypatch.setattr(runner, "build_drive_service", lambda: drive)
+    monkeypatch.setattr(runner, "build_docs_service", lambda: docs)
+    monkeypatch.setattr(runner, "list_all_shared_docs", lambda svc: [{"id": "1"}, {"id": "2"}])
+
+    processed: list[str] = []
+
+    def fake_process(drive_service, docs_service, file):
+        processed.append(file["id"])
+        return True
+
+    monkeypatch.setattr(runner, "_process_document", fake_process)
+    monkeypatch.setattr(runner, "run_once", lambda d, ds, s, t: (s, t))
+
+    import types, sys
+
+    class FakeEvery:
+        @property
+        def minutes(self):
+            return self
+
+        def do(self, func):
+            self.func = func
+            return self
+
+    class FakeSchedule(types.SimpleNamespace):
+        def every(self, *args, **kwargs):
+            return FakeEvery()
+
+        def run_pending(self):
+            raise KeyboardInterrupt()
+
+    fake_schedule = FakeSchedule()
+    monkeypatch.setitem(sys.modules, "schedule", fake_schedule)
+    monkeypatch.setattr(runner.time, "sleep", lambda _x: None)
+
+    runner.main()
+
+    assert processed == ["1", "2"]


### PR DESCRIPTION
## Summary
- add `list_all_shared_docs` helper to enumerate all Docs shared with the service account
- seed runner by processing all previously shared documents before starting incremental loop
- test coverage for initial seeding and new Drive helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a686bef62c83289731474f3125749a