### PR TITLE
feat: review comment replies for guidance

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from .google_docs import build_docs_service
 from .groq_client import get_suggestions
 from .time_utils import parse_google_timestamp
 from requests import HTTPError
-from .review import review_document, post_comments
+from .review import review_document, post_comments, review_comment_replies
 
 # Configure logging
 logging.basicConfig(
@@ -89,7 +89,7 @@ def _process_document(
             )
         else:
             logger.info("No comments to post for document '%s'", doc_name)
-
+        review_comment_replies(drive_service, doc_id, groq_suggest)
         return True
     except Exception as e:  # pragma: no cover - logging path
         logger.error(

--- a/src/review.py
+++ b/src/review.py
@@ -21,6 +21,8 @@ from .google_drive import (
     update_app_properties,
     reply_to_comment,
     create_comment,
+    list_comments,
+    list_replies,
 )
 
 
@@ -304,3 +306,74 @@ def post_comments(
                     comment.get("id"),
                     document_id,
                 )
+
+
+def review_comment_replies(
+    drive_service: Any, doc_id: str, review_fn: Callable[[str, str], dict[str, Any]]
+) -> None:
+    """Evaluate replies to the service account's comments.
+
+    For each comment thread authored by the service account, new replies are
+    passed to ``review_fn``. The function may return a ``reply`` string to post
+    guidance and a ``resolve`` flag to mark the thread as resolved.
+    """
+
+    try:
+        about = (
+            drive_service.about()
+            .get(fields="user(displayName)")
+            .execute(num_retries=3)
+        )
+        author_name = about.get("user", {}).get("displayName", "")
+    except Exception:
+        logging.exception("Failed to fetch service account display name")
+        author_name = ""
+
+    threads = list_comments(drive_service, doc_id)
+    for thread in threads:
+        if thread.get("author", {}).get("displayName") != author_name:
+            continue
+        comment_id = thread.get("id")
+        replies = list_replies(drive_service, doc_id, comment_id)
+        last_own_reply = -1
+        for idx, rep in enumerate(replies):
+            if rep.get("author", {}).get("displayName") == author_name:
+                last_own_reply = idx
+        for reply in replies[last_own_reply + 1 :]:
+            if reply.get("author", {}).get("displayName") == author_name:
+                continue
+            review = review_fn(reply.get("content", ""), thread.get("content", ""))
+            if not isinstance(review, dict):
+                continue
+            response = review.get("reply") or review.get("response")
+            resolve = review.get("resolve")
+            if response:
+                try:
+                    _retry_with_backoff(
+                        reply_to_comment, drive_service, doc_id, comment_id, response
+                    )
+                except Exception:
+                    logging.exception(
+                        "Failed to reply to comment %s for %s", comment_id, doc_id
+                    )
+            if resolve:
+                try:
+                    def _resolve_comment(
+                        service: Any, file_id: str, comment_id: str
+                    ) -> Any:
+                        return (
+                            service.comments()
+                            .update(
+                                fileId=file_id,
+                                commentId=comment_id,
+                                body={"resolved": True},
+                                fields="id",
+                            )
+                            .execute(num_retries=3)
+                        )
+
+                    _retry_with_backoff(_resolve_comment, drive_service, doc_id, comment_id)
+                except Exception:
+                    logging.exception(
+                        "Failed to resolve comment %s for %s", comment_id, doc_id
+                    )

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+from typing import Any
 
 from src.review import (
     _hash,
@@ -9,6 +10,7 @@ from src.review import (
     process_changed_ranges,
     post_comments,
     review_document,
+    review_comment_replies,
     SUGGESTION_HASHES_KEY,
 )
 
@@ -304,3 +306,58 @@ def test_split_into_byte_chunks_utf8_boundary():
     chunks = split_into_byte_chunks(text, max_bytes)
     assert all(len(chunk.encode("utf-8")) <= max_bytes for chunk in chunks)
     assert "".join(chunks) == text
+
+
+def test_review_comment_replies(monkeypatch):
+    drive = MagicMock()
+    drive.about.return_value.get.return_value.execute.return_value = {
+        "user": {"displayName": "Bot"}
+    }
+
+    def fake_list_comments(service, file_id):
+        return [
+            {"id": "c1", "author": {"displayName": "Bot"}, "content": "orig"},
+            {"id": "c2", "author": {"displayName": "User"}},
+        ]
+
+    def fake_list_replies(service, file_id, comment_id):
+        if comment_id == "c1":
+            return [
+                {"id": "r0", "author": {"displayName": "Bot"}, "content": "old"},
+                {"id": "r1", "author": {"displayName": "User"}, "content": "bad"},
+            ]
+        return []
+
+    reply_calls: list[tuple[str, str, str]] = []
+
+    def fake_reply(service, file_id, comment_id, content):
+        reply_calls.append((file_id, comment_id, content))
+
+    update_calls: list[tuple[str, str]] = []
+
+    def fake_update(fileId=None, commentId=None, body=None, fields=None):
+        update_calls.append((fileId, commentId))
+
+        class Exec:
+            def execute(self, num_retries=3):
+                return {"id": commentId}
+
+        return Exec()
+
+    drive.comments.return_value.update.side_effect = fake_update
+
+    monkeypatch.setattr("src.review.list_comments", fake_list_comments)
+    monkeypatch.setattr("src.review.list_replies", fake_list_replies)
+    monkeypatch.setattr("src.review.reply_to_comment", fake_reply)
+
+    reviewed: list[tuple[str, str]] = []
+
+    def review_fn(text: str, context: str) -> dict[str, Any]:
+        reviewed.append((text, context))
+        return {"reply": "guidance", "resolve": True}
+
+    review_comment_replies(drive, "doc1", review_fn)
+
+    assert reviewed == [("bad", "orig")]
+    assert reply_calls == [("doc1", "c1", "guidance")]
+    assert update_calls == [("doc1", "c1")]

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -59,6 +59,7 @@ def test_process_document_success(monkeypatch):
         posted.append((doc_id, items))
 
     monkeypatch.setattr("src.main.post_comments", fake_post)
+    monkeypatch.setattr("src.main.review_comment_replies", lambda *_args: None)
 
     assert _process_document(drive, docs, file) is True
     assert posted == [("1", [{"suggestion": "s1"}])]


### PR DESCRIPTION
## Summary
- detect and handle replies to service account comments
- review replies each cycle and respond or resolve threads automatically
- test reply review logic with mocked Drive API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a688955ad88328a3645b6287a7fce0