### PR TITLE
Handle missing permission IDs after Drive re-share

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -98,6 +98,7 @@ def list_recent_changes(
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
             "pageSize": 1000,
+            "includePermissionsForView": "published",
         }
         results = service.changes().list(**params).execute(num_retries=3)
         changes = results.get("changes", [])
@@ -187,6 +188,20 @@ def list_recent_docs(
         if permission_id in f.get("permissionIds", []):
             f.pop("permissionIds", None)
             change_files_filtered.append(f)
+            continue
+
+        if "permissionIds" not in f:
+            fid = f.get("id")
+            if not fid:
+                continue
+            perms = (
+                service.permissions()
+                .list(fileId=fid, fields="permissions(id)")
+                .execute(num_retries=3)
+            )
+            ids = [p.get("id") for p in perms.get("permissions", [])]
+            if permission_id in ids:
+                change_files_filtered.append(f)
     logger.info(
         "Change feed returned %d docs after filtering; new change token %s",
         len(change_files_filtered),

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -229,6 +229,53 @@ def test_list_recent_docs_skips_changes_without_service_permission():
     assert token == "t1"
 
 
+def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
+    """A document unshared and then re-shared should be included for review."""
+    service = MagicMock()
+    service.about.return_value.get.return_value.execute.return_value = {
+        "user": {"permissionId": "pid"}
+    }
+    service.files.return_value.list.return_value.execute.return_value = {"files": []}
+    # Changes feed omits permissionIds for the re-shared doc
+    service.changes.return_value.list.return_value.execute.return_value = {
+        "changes": [
+            {"removed": True},
+            {
+                "file": {
+                    "id": "1",
+                    "name": "Reshared",
+                    "mimeType": "application/vnd.google-apps.document",
+                    "modifiedTime": "2020-01-01T00:00:00Z",
+                    "createdTime": "2020-01-01T00:00:00Z",
+                    "sharedWithMeTime": "2024-01-01T00:00:00Z",
+                }
+            },
+        ],
+        "newStartPageToken": "t1",
+    }
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": [{"id": "pid"}]
+    }
+
+    since = datetime(2024, 1, 1)
+    files, token = list_recent_docs(service, since, "t0")
+
+    assert files == [
+        {
+            "id": "1",
+            "name": "Reshared",
+            "mimeType": "application/vnd.google-apps.document",
+            "modifiedTime": "2020-01-01T00:00:00Z",
+            "createdTime": "2020-01-01T00:00:00Z",
+            "sharedWithMeTime": "2024-01-01T00:00:00Z",
+        }
+    ]
+    assert token == "t1"
+    service.permissions.return_value.list.assert_called_once_with(
+        fileId="1", fields="permissions(id)"
+    )
+
+
 def test_app_properties_roundtrip():
     service = MagicMock()
     service.files.return_value.get.return_value.execute.return_value = {


### PR DESCRIPTION
## Summary
- include permission data when listing Drive changes
- fallback to permissions.list when change lacks permission IDs
- test Drive re-share workflow to ensure files are reviewed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68b58c8488328a2b6a4b86912b789