### PR TITLE
feat: track and reprocess shared docs

### DIFF
--- a/src/document_cache.py
+++ b/src/document_cache.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Set
+
+
+class DocumentCache:
+    """Persistent set of document IDs stored in a JSON file."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self.ids: Set[str] = set()
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            data = json.loads(self.path.read_text("utf-8"))
+            if isinstance(data, list):
+                self.ids = set(str(x) for x in data)
+        except FileNotFoundError:
+            self.ids = set()
+        except json.JSONDecodeError:
+            self.ids = set()
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(sorted(self.ids)), encoding="utf-8")

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from .groq_client import get_suggestions
 from .time_utils import parse_google_timestamp
 from requests import HTTPError
 from .review import review_document, post_comments, review_comment_replies
+from .document_cache import DocumentCache
 
 # Configure logging
 logging.basicConfig(
@@ -22,6 +23,9 @@ logging.basicConfig(
     ]
 )
 logger = logging.getLogger(__name__)
+
+DOC_CACHE_PATH = "processed_docs.json"
+_DOC_CACHE = DocumentCache(DOC_CACHE_PATH)
 
 
 def groq_suggest(text: str, context: str) -> dict[str, str]:
@@ -120,7 +124,11 @@ def _latest_timestamp(file: dict[str, Any], current: datetime) -> datetime:
 
 
 def run_once(
-    drive_service: Any, docs_service: Any, since: datetime, page_token: str
+    drive_service: Any,
+    docs_service: Any,
+    since: datetime,
+    page_token: str,
+    doc_cache: DocumentCache | None = None,
 ) -> tuple[datetime, str]:
     """Process documents changed since ``since`` and return new timestamp and token.
 
@@ -129,11 +137,18 @@ def run_once(
     used to query the Drive changes feed for permission updates.
     """
 
+    cache = doc_cache or _DOC_CACHE
+
     logger.info(
         "Starting document review cycle. Checking for documents changed since: %s",
         since,
     )
     logger.info("Using change page token: %s", page_token)
+
+    shared_docs = list_all_shared_docs(drive_service)
+    current_ids = {f.get("id") for f in shared_docs if f.get("id")}
+    new_shared_ids = current_ids - cache.ids
+    extra_files = [f for f in shared_docs if f.get("id") in new_shared_ids]
 
     try:
         files, new_page_token = list_recent_docs(drive_service, since, page_token)
@@ -147,6 +162,13 @@ def run_once(
         files = []
         new_page_token = page_token
 
+    existing_ids = {f.get("id") for f in files}
+    for f in extra_files:
+        fid = f.get("id")
+        if fid and fid not in existing_ids:
+            files.append(f)
+            existing_ids.add(fid)
+
     processed_count = 0
     latest_time = since
     for f in files:
@@ -159,6 +181,9 @@ def run_once(
         processed_count,
         len(files),
     )
+
+    cache.ids = current_ids
+    cache.save()
 
     new_timestamp = max(latest_time, datetime.utcnow())
     logger.info(
@@ -203,7 +228,9 @@ def main() -> None:
             nonlocal since, page_token
             logger.info("=" * 60)
             logger.info("Scheduled job triggered - starting document review")
-            since, page_token = run_once(drive_service, docs_service, since, page_token)
+            since, page_token = run_once(
+                drive_service, docs_service, since, page_token, _DOC_CACHE
+            )
             logger.info("Scheduled job completed")
             logger.info("=" * 60)
         

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -1,17 +1,20 @@
 from datetime import datetime
+import json
 from unittest.mock import MagicMock
 
 from src.main import run_once, _process_document, _latest_timestamp
+from src.document_cache import DocumentCache
 import src.main as runner
 
 
-def test_run_once_reviews_and_posts(monkeypatch):
+def test_run_once_reviews_and_posts(monkeypatch, tmp_path):
     drive = MagicMock()
     docs = MagicMock()
     monkeypatch.setattr(
         "src.main.list_recent_docs",
         lambda svc, since, token: ([{"id": "1"}, {"id": "2"}], token),
     )
+    monkeypatch.setattr("src.main.list_all_shared_docs", lambda svc: [])
 
     reviews = [
         [{"suggestion": "s1", "hash": "h1", "start_index": 0, "end_index": 1}],
@@ -31,7 +34,8 @@ def test_run_once_reviews_and_posts(monkeypatch):
     monkeypatch.setattr("src.main.post_comments", fake_post)
 
     since = datetime.utcnow()
-    new_since, new_token = run_once(drive, docs, since, "t0")
+    cache = DocumentCache(tmp_path / "cache.json")
+    new_since, new_token = run_once(drive, docs, since, "t0", cache)
 
     assert posted == [(
         "1",
@@ -105,7 +109,7 @@ def test_main_processes_pre_shared_docs(monkeypatch):
         return True
 
     monkeypatch.setattr(runner, "_process_document", fake_process)
-    monkeypatch.setattr(runner, "run_once", lambda d, ds, s, t: (s, t))
+    monkeypatch.setattr(runner, "run_once", lambda d, ds, s, t, c=None: (s, t))
 
     import types, sys
 
@@ -132,3 +136,60 @@ def test_main_processes_pre_shared_docs(monkeypatch):
     runner.main()
 
     assert processed == ["1", "2"]
+
+
+def test_reshared_docs_are_reprocessed(monkeypatch, tmp_path):
+    drive = MagicMock()
+    docs = MagicMock()
+    cache = DocumentCache(tmp_path / "cache.json")
+
+    shared_states = [
+        [{"id": "1"}],
+        [],
+        [{"id": "1"}],
+    ]
+
+    def fake_all(_svc):
+        return shared_states.pop(0)
+
+    recent_states = [
+        ([], "t1"),
+        ([], "t2"),
+        ([], "t3"),
+    ]
+
+    def fake_recent(_svc, _since, _token):
+        return recent_states.pop(0)
+
+    monkeypatch.setattr("src.main.list_all_shared_docs", fake_all)
+    monkeypatch.setattr("src.main.list_recent_docs", fake_recent)
+
+    processed: list[str] = []
+
+    def fake_process(drive_service, docs_service, file):
+        processed.append(file["id"])
+        return True
+
+    monkeypatch.setattr("src.main._process_document", fake_process)
+
+    since = datetime.utcnow()
+    token = "t0"
+
+    since, token = run_once(drive, docs, since, token, cache)
+    assert cache.ids == {"1"}
+
+    with open(cache.path) as f:
+        assert json.load(f) == ["1"]
+
+    since, token = run_once(drive, docs, since, token, cache)
+    assert cache.ids == set()
+
+    with open(cache.path) as f:
+        assert json.load(f) == []
+
+    since, token = run_once(drive, docs, since, token, cache)
+
+    assert processed == ["1", "1"]
+
+    with open(cache.path) as f:
+        assert json.load(f) == ["1"]


### PR DESCRIPTION
## Summary
- track processed document IDs using a JSON-backed cache
- refresh cache each run to detect newly shared or re-shared docs
- add test coverage for reprocessing re-shared documents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68d0bbf04832888cee54c1039460e