### PR TITLE
Use service account email to find shared Docs

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -19,6 +19,16 @@ def build_drive_service() -> Any:
     return build_service("drive", "v3", SCOPES)
 
 
+def _get_service_account_email(service: Any) -> str:
+    """Return the email address for the authenticated service account."""
+    about = (
+        service.about()
+        .get(fields="user(emailAddress)")
+        .execute(num_retries=3)
+    )
+    return about.get("user", {}).get("emailAddress", "")
+
+
 def _get_permission_id(service: Any) -> str:
     """Return the Drive permission ID for the authenticated service account."""
     about = (
@@ -39,7 +49,11 @@ def list_all_shared_docs(service: Any) -> list[dict[str, Any]]:
     """
 
     logger.info("Listing all shared Google Docs")
-    query = "mimeType='application/vnd.google-apps.document' and sharedWithMe"
+    email = _get_service_account_email(service)
+    query = (
+        "mimeType='application/vnd.google-apps.document' and ("
+        f"'{email}' in readers or '{email}' in writers or '{email}' in owners)"
+    )
     files: list[dict[str, Any]] = []
     page: str | None = None
     while True:


### PR DESCRIPTION
## Summary
- add helper to retrieve Drive service account email
- search for shared Docs using service account email across permissions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a58438d8832885ba3bb955fe3733