### PR TITLE
feat: support drive-specific change tokens

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -39,6 +39,55 @@ def _get_permission_id(service: Any) -> str:
     return about.get("user", {}).get("permissionId", "")
 
 
+def list_all_drive_ids(service: Any) -> list[str]:
+    """Return IDs for all shared drives accessible to the service account."""
+    logger.info("Listing all accessible drive IDs")
+    drive_ids: list[str] = []
+    page: str | None = None
+    while True:
+        params = {
+            "fields": "nextPageToken, drives(id)",
+            "pageSize": 100,
+        }
+        if page:
+            params["pageToken"] = page
+        results = service.drives().list(**params).execute(num_retries=3)
+        batch = [d.get("id") for d in results.get("drives", []) if d.get("id")]
+        drive_ids.extend(batch)
+        logger.info(
+            "Retrieved %d drive ids (nextPageToken=%s)",
+            len(batch),
+            results.get("nextPageToken"),
+        )
+        page = results.get("nextPageToken")
+        if not page:
+            break
+
+    logger.info("Total %d drive ids retrieved", len(drive_ids))
+    return drive_ids
+
+
+def get_start_page_tokens(service: Any) -> dict[str, str]:
+    """Return mapping of drive identifiers to change feed start page tokens."""
+    tokens: dict[str, str] = {}
+    user_token = (
+        service.changes()
+        .getStartPageToken(supportsAllDrives=True)
+        .execute(num_retries=3)
+        .get("startPageToken", "")
+    )
+    tokens["user"] = user_token
+    for drive_id in list_all_drive_ids(service):
+        token = (
+            service.changes()
+            .getStartPageToken(driveId=drive_id, supportsAllDrives=True)
+            .execute(num_retries=3)
+            .get("startPageToken", "")
+        )
+        tokens[drive_id] = token
+    return tokens
+
+
 def list_all_shared_docs(service: Any) -> list[dict[str, Any]]:
     """Return all Google Docs currently shared with the service account.
 
@@ -85,20 +134,16 @@ def list_all_shared_docs(service: Any) -> list[dict[str, Any]]:
     return files
 
 
-def list_recent_changes(
-    service: Any, page_token: str
+def _list_drive_changes(
+    service: Any, page_token: str, drive_id: str | None = None
 ) -> tuple[list[dict[str, Any]], str]:
-    """Return files whose metadata or permissions changed since ``page_token``.
+    """Return Drive change records for a specific drive or the user feed."""
 
-    Parameters
-    ----------
-    service
-        Authenticated Google Drive service instance.
-    page_token
-        Change page token retrieved from ``changes().getStartPageToken``.
-    """
-
-    logger.info("Fetching Drive changes starting from page token %s", page_token)
+    logger.info(
+        "Fetching Drive changes starting from page token %s (drive_id=%s)",
+        page_token,
+        drive_id or "user",
+    )
     files: list[dict[str, Any]] = []
     token = page_token
     while True:
@@ -114,6 +159,8 @@ def list_recent_changes(
             "pageSize": 1000,
             "includePermissionsForView": "published",
         }
+        if drive_id:
+            params["driveId"] = drive_id
         results = service.changes().list(**params).execute(num_retries=3)
         changes = results.get("changes", [])
         logger.info(
@@ -138,10 +185,33 @@ def list_recent_changes(
             return files, new_token
 
 
+def list_recent_changes_all(
+    service: Any, page_tokens: dict[str, str]
+) -> tuple[list[dict[str, Any]], dict[str, str]]:
+    """Return aggregated Drive changes for all tracked drives.
+
+    Parameters
+    ----------
+    service
+        Authenticated Google Drive service instance.
+    page_tokens
+        Mapping of ``drive_id`` (or ``"user"``) to their last seen page token.
+    """
+
+    all_files: list[dict[str, Any]] = []
+    new_tokens: dict[str, str] = {}
+    for key, token in page_tokens.items():
+        drive_id = None if key == "user" else key
+        files, new_token = _list_drive_changes(service, token, drive_id)
+        all_files.extend(files)
+        new_tokens[key] = new_token
+    return all_files, new_tokens
+
+
 def list_recent_docs(
-    service: Any, since_time: datetime, page_token: str
-) -> tuple[list[dict[str, Any]], str]:
-    """Return Google Docs changed or shared since ``since_time`` and ``page_token``.
+    service: Any, since_time: datetime, page_tokens: dict[str, str]
+) -> tuple[list[dict[str, Any]], dict[str, str]]:
+    """Return Google Docs changed or shared since ``since_time`` using change tokens.
 
     Parameters
     ----------
@@ -150,8 +220,8 @@ def list_recent_docs(
     since_time
         ``datetime`` of the last run. Documents with ``modifiedTime`` after this
         timestamp are returned.
-    page_token
-        Change page token from the previous run used to query the changes feed.
+    page_tokens
+        Mapping of change page tokens from the previous run for each tracked drive.
     """
 
     iso_time = since_time.replace(microsecond=0).isoformat("T") + "Z"
@@ -196,7 +266,7 @@ def list_recent_docs(
 
     # Fetch changes to catch newly shared docs
     permission_id = _get_permission_id(service)
-    change_files, new_page_token = list_recent_changes(service, page_token)
+    change_files, new_page_tokens = list_recent_changes_all(service, page_tokens)
     change_files_filtered: list[dict[str, Any]] = []
     for f in change_files:
         if permission_id in f.get("permissionIds", []):
@@ -219,7 +289,7 @@ def list_recent_docs(
     logger.info(
         "Change feed returned %d docs after filtering; new change token %s",
         len(change_files_filtered),
-        new_page_token,
+        new_page_tokens,
     )
 
     files_by_id = {f["id"]: f for f in files}
@@ -279,7 +349,7 @@ def list_recent_docs(
 
     logger.info("Returning %d documents after filtering", len(recent_files))
 
-    return recent_files, new_page_token
+    return recent_files, new_page_tokens
 
 
 def get_app_properties(service: Any, file_id: str) -> tuple[dict[str, str], str]:

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,12 @@ import logging
 import time
 from typing import Any
 
-from .google_drive import build_drive_service, list_recent_docs, list_all_shared_docs
+from .google_drive import (
+    build_drive_service,
+    list_recent_docs,
+    list_all_shared_docs,
+    get_start_page_tokens,
+)
 from .google_docs import build_docs_service
 from .groq_client import get_suggestions
 from .time_utils import parse_google_timestamp
@@ -127,14 +132,15 @@ def run_once(
     drive_service: Any,
     docs_service: Any,
     since: datetime,
-    page_token: str,
+    page_tokens: dict[str, str],
     doc_cache: DocumentCache | None = None,
-) -> tuple[datetime, str]:
-    """Process documents changed since ``since`` and return new timestamp and token.
+) -> tuple[datetime, dict[str, str]]:
+    """Process documents changed since ``since`` and return new timestamp and tokens.
 
     Documents are considered changed if they were modified or newly shared with
-    the service account after the provided ``since`` timestamp. ``page_token`` is
-    used to query the Drive changes feed for permission updates.
+    the service account after the provided ``since`` timestamp. ``page_tokens`` is
+    a mapping of Drive change tokens used to query the Drive changes feed for
+    permission updates across all drives.
     """
 
     cache = doc_cache or _DOC_CACHE
@@ -143,7 +149,7 @@ def run_once(
         "Starting document review cycle. Checking for documents changed since: %s",
         since,
     )
-    logger.info("Using change page token: %s", page_token)
+    logger.info("Using change page tokens: %s", page_tokens)
 
     shared_docs = list_all_shared_docs(drive_service)
     current_ids = {f.get("id") for f in shared_docs if f.get("id")}
@@ -151,16 +157,18 @@ def run_once(
     extra_files = [f for f in shared_docs if f.get("id") in new_shared_ids]
 
     try:
-        files, new_page_token = list_recent_docs(drive_service, since, page_token)
+        files, new_page_tokens = list_recent_docs(
+            drive_service, since, page_tokens
+        )
         logger.info(
             "Found %d documents to process (new change token: %s)",
             len(files),
-            new_page_token,
+            new_page_tokens,
         )
     except Exception as e:  # pragma: no cover - logging path
         logger.error(f"Error during document review cycle: {e}")
         files = []
-        new_page_token = page_token
+        new_page_tokens = page_tokens
 
     existing_ids = {f.get("id") for f in files}
     for f in extra_files:
@@ -190,7 +198,7 @@ def run_once(
         "Next review cycle will check for documents changed after: %s",
         new_timestamp,
     )
-    return new_timestamp, new_page_token
+    return new_timestamp, new_page_tokens
 
 
 def main() -> None:
@@ -214,22 +222,17 @@ def main() -> None:
 
         since = datetime.utcnow()
         logger.info(f"Initial timestamp set to: {since}")
-        page_token = (
-            drive_service.changes()
-            .getStartPageToken(supportsAllDrives=True)
-            .execute()
-            .get("startPageToken", "")
-        )
-        logger.info(f"Initial change token set to: {page_token}")
+        page_tokens = get_start_page_tokens(drive_service)
+        logger.info(f"Initial change tokens set to: {page_tokens}")
         
         import schedule
         
         def job() -> None:
-            nonlocal since, page_token
+            nonlocal since, page_tokens
             logger.info("=" * 60)
             logger.info("Scheduled job triggered - starting document review")
-            since, page_token = run_once(
-                drive_service, docs_service, since, page_token, _DOC_CACHE
+            since, page_tokens = run_once(
+                drive_service, docs_service, since, page_tokens, _DOC_CACHE
             )
             logger.info("Scheduled job completed")
             logger.info("=" * 60)

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -47,12 +47,12 @@ def test_list_recent_docs_filters_by_time():
     }
 
     since = datetime(2023, 12, 31, 23, 0, 0)
-    files, token = list_recent_docs(service, since, "t0")
+    files, tokens = list_recent_docs(service, since, {"user": "t0"})
 
     assert service.files.return_value.list.call_count == 1
     assert service.changes.return_value.list.call_count == 1
     assert files[0]["name"] == "Doc1"
-    assert token == "t1"
+    assert tokens == {"user": "t1"}
 
 
 def test_list_recent_docs_includes_newly_shared_docs():
@@ -81,7 +81,7 @@ def test_list_recent_docs_includes_newly_shared_docs():
     }
 
     since = datetime(2024, 1, 1, 12, 0, 0)
-    files, _ = list_recent_docs(service, since, "t0")
+    files, _ = list_recent_docs(service, since, {"user": "t0"})
 
     assert service.files.return_value.list.call_count == 1
     assert service.changes.return_value.list.call_count == 1
@@ -119,7 +119,7 @@ def test_list_recent_docs_parses_microsecond_timestamps():
         "newStartPageToken": "t1",
     }
     since = datetime(2024, 1, 1, 23, 59, 59)
-    files, _ = list_recent_docs(service, since, "t0")
+    files, _ = list_recent_docs(service, since, {"user": "t0"})
     assert {f["name"] for f in files} == {"Micro", "CreatedMicro"}
 
 
@@ -154,7 +154,7 @@ def test_list_recent_docs_handles_pagination():
     service.changes.return_value.list.return_value.execute.side_effect = change_pages
 
     since = datetime(2024, 1, 1, 12, 0, 0)
-    files, token = list_recent_docs(service, since, "c0")
+    files, tokens = list_recent_docs(service, since, {"user": "c0"})
     assert files == [
         {
             "id": "new",
@@ -164,7 +164,7 @@ def test_list_recent_docs_handles_pagination():
             "modifiedTime": "2024-01-01T00:00:00Z",
         }
     ]
-    assert token == "c2"
+    assert tokens == {"user": "c2"}
     assert service.files.return_value.list.call_count == 2
     assert service.changes.return_value.list.call_count == 2
 
@@ -192,7 +192,7 @@ def test_list_recent_docs_detects_permission_changes_without_shared_time():
     }
 
     since = datetime(2024, 1, 1, 0, 0, 0)
-    files, _ = list_recent_docs(service, since, "t0")
+    files, _ = list_recent_docs(service, since, {"user": "t0"})
     assert files == [
         {
             "id": "1",
@@ -224,9 +224,9 @@ def test_list_recent_docs_skips_changes_without_service_permission():
         "newStartPageToken": "t1",
     }
     since = datetime(2024, 1, 1)
-    files, token = list_recent_docs(service, since, "t0")
+    files, tokens = list_recent_docs(service, since, {"user": "t0"})
     assert files == []
-    assert token == "t1"
+    assert tokens == {"user": "t1"}
 
 
 def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
@@ -258,7 +258,7 @@ def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
     }
 
     since = datetime(2024, 1, 1)
-    files, token = list_recent_docs(service, since, "t0")
+    files, tokens = list_recent_docs(service, since, {"user": "t0"})
 
     assert files == [
         {
@@ -270,7 +270,7 @@ def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
             "sharedWithMeTime": "2024-01-01T00:00:00Z",
         }
     ]
-    assert token == "t1"
+    assert tokens == {"user": "t1"}
     service.permissions.return_value.list.assert_called_once_with(
         fileId="1", fields="permissions(id)"
     )

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -12,7 +12,7 @@ def test_run_once_reviews_and_posts(monkeypatch, tmp_path):
     docs = MagicMock()
     monkeypatch.setattr(
         "src.main.list_recent_docs",
-        lambda svc, since, token: ([{"id": "1"}, {"id": "2"}], token),
+        lambda svc, since, tokens: ([{"id": "1"}, {"id": "2"}], tokens),
     )
     monkeypatch.setattr("src.main.list_all_shared_docs", lambda svc: [])
 
@@ -35,14 +35,14 @@ def test_run_once_reviews_and_posts(monkeypatch, tmp_path):
 
     since = datetime.utcnow()
     cache = DocumentCache(tmp_path / "cache.json")
-    new_since, new_token = run_once(drive, docs, since, "t0", cache)
+    new_since, new_tokens = run_once(drive, docs, since, {"user": "t0"}, cache)
 
     assert posted == [(
         "1",
         [{"suggestion": "s1", "hash": "h1", "start_index": 0, "end_index": 1}],
     )]
     assert isinstance(new_since, datetime) and new_since >= since
-    assert new_token == "t0"
+    assert new_tokens == {"user": "t0"}
 
 
 def test_process_document_success(monkeypatch):
@@ -94,13 +94,11 @@ def test_latest_timestamp():
 
 def test_main_processes_pre_shared_docs(monkeypatch):
     drive = MagicMock()
-    drive.changes.return_value.getStartPageToken.return_value.execute.return_value = {
-        "startPageToken": "t0"
-    }
     docs = MagicMock()
     monkeypatch.setattr(runner, "build_drive_service", lambda: drive)
     monkeypatch.setattr(runner, "build_docs_service", lambda: docs)
     monkeypatch.setattr(runner, "list_all_shared_docs", lambda svc: [{"id": "1"}, {"id": "2"}])
+    monkeypatch.setattr(runner, "get_start_page_tokens", lambda svc: {"user": "t0"})
 
     processed: list[str] = []
 
@@ -153,12 +151,12 @@ def test_reshared_docs_are_reprocessed(monkeypatch, tmp_path):
         return shared_states.pop(0)
 
     recent_states = [
-        ([], "t1"),
-        ([], "t2"),
-        ([], "t3"),
+        ([], {"user": "t1"}),
+        ([], {"user": "t2"}),
+        ([], {"user": "t3"}),
     ]
 
-    def fake_recent(_svc, _since, _token):
+    def fake_recent(_svc, _since, _tokens):
         return recent_states.pop(0)
 
     monkeypatch.setattr("src.main.list_all_shared_docs", fake_all)
@@ -173,21 +171,21 @@ def test_reshared_docs_are_reprocessed(monkeypatch, tmp_path):
     monkeypatch.setattr("src.main._process_document", fake_process)
 
     since = datetime.utcnow()
-    token = "t0"
+    tokens = {"user": "t0"}
 
-    since, token = run_once(drive, docs, since, token, cache)
+    since, tokens = run_once(drive, docs, since, tokens, cache)
     assert cache.ids == {"1"}
 
     with open(cache.path) as f:
         assert json.load(f) == ["1"]
 
-    since, token = run_once(drive, docs, since, token, cache)
+    since, tokens = run_once(drive, docs, since, tokens, cache)
     assert cache.ids == set()
 
     with open(cache.path) as f:
         assert json.load(f) == []
 
-    since, token = run_once(drive, docs, since, token, cache)
+    since, tokens = run_once(drive, docs, since, tokens, cache)
 
     assert processed == ["1", "1"]
 


### PR DESCRIPTION
## Summary
- add drive ID discovery and token tracking across all drives
- iterate change feed per drive using stored page tokens
- refactor document review pipeline to use token dictionaries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6aa052d2083288111ab5957626833