### PR TITLE
Handle missing Drive permissionIds using capability check

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -269,23 +269,25 @@ def list_recent_docs(
     change_files, new_page_tokens = list_recent_changes_all(service, page_tokens)
     change_files_filtered: list[dict[str, Any]] = []
     for f in change_files:
-        if permission_id in f.get("permissionIds", []):
-            f.pop("permissionIds", None)
-            change_files_filtered.append(f)
+        fid = f.get("id")
+        if not fid:
             continue
-
-        if "permissionIds" not in f:
-            fid = f.get("id")
-            if not fid:
-                continue
-            perms = (
-                service.permissions()
-                .list(fileId=fid, fields="permissions(id)")
+        perm_ids = f.get("permissionIds", [])
+        has_access = permission_id in perm_ids
+        f.pop("permissionIds", None)
+        if not has_access:
+            info = (
+                service.files()
+                .get(fileId=fid, fields="id,capabilities(canRead,canComment)")
                 .execute(num_retries=3)
             )
-            ids = [p.get("id") for p in perms.get("permissions", [])]
-            if permission_id in ids:
-                change_files_filtered.append(f)
+            has_access = (
+                info.get("capabilities", {}).get("canRead") is True
+                if isinstance(info, dict)
+                else False
+            )
+        if has_access:
+            change_files_filtered.append(f)
     logger.info(
         "Change feed returned %d docs after filtering; new change token %s",
         len(change_files_filtered),

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -223,10 +223,17 @@ def test_list_recent_docs_skips_changes_without_service_permission():
         ],
         "newStartPageToken": "t1",
     }
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "1",
+        "capabilities": {"canRead": False, "canComment": False},
+    }
     since = datetime(2024, 1, 1)
     files, tokens = list_recent_docs(service, since, {"user": "t0"})
     assert files == []
     assert tokens == {"user": "t1"}
+    service.files.return_value.get.assert_called_once_with(
+        fileId="1", fields="id,capabilities(canRead,canComment)"
+    )
 
 
 def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
@@ -253,8 +260,9 @@ def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
         ],
         "newStartPageToken": "t1",
     }
-    service.permissions.return_value.list.return_value.execute.return_value = {
-        "permissions": [{"id": "pid"}]
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "1",
+        "capabilities": {"canRead": True, "canComment": True},
     }
 
     since = datetime(2024, 1, 1)
@@ -271,8 +279,8 @@ def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
         }
     ]
     assert tokens == {"user": "t1"}
-    service.permissions.return_value.list.assert_called_once_with(
-        fileId="1", fields="permissions(id)"
+    service.files.return_value.get.assert_called_once_with(
+        fileId="1", fields="id,capabilities(canRead,canComment)"
     )
 
 


### PR DESCRIPTION
## Summary
- When processing Drive change files, check file capabilities if permissionIds don't include the service account
- Only exclude change entries when the service account truly lacks read access
- Adjust tests for new capability-based access filtering

## Testing
- `pytest test/test_google_drive.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6ab487df48328b9762282addfb4b3