### PR TITLE
Add detailed Drive logging

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -26,7 +26,9 @@ def _get_service_account_email(service: Any) -> str:
         .get(fields="user(emailAddress)")
         .execute(num_retries=3)
     )
-    return about.get("user", {}).get("emailAddress", "")
+    email = about.get("user", {}).get("emailAddress", "")
+    logger.info("Service account email: %s", email)
+    return email
 
 
 def _get_permission_id(service: Any) -> str:
@@ -36,34 +38,43 @@ def _get_permission_id(service: Any) -> str:
         .get(fields="user(permissionId)")
         .execute(num_retries=3)
     )
-    return about.get("user", {}).get("permissionId", "")
+    perm_id = about.get("user", {}).get("permissionId", "")
+    logger.info("Service account permission ID: %s", perm_id)
+    return perm_id
 
 
 def list_all_drive_ids(service: Any) -> list[str]:
     """Return IDs for all shared drives accessible to the service account."""
     logger.info("Listing all accessible drive IDs")
     drive_ids: list[str] = []
+    drive_names: list[str] = []
     page: str | None = None
     while True:
         params = {
-            "fields": "nextPageToken, drives(id)",
+            "fields": "nextPageToken, drives(id,name)",
             "pageSize": 100,
         }
         if page:
             params["pageToken"] = page
         results = service.drives().list(**params).execute(num_retries=3)
-        batch = [d.get("id") for d in results.get("drives", []) if d.get("id")]
-        drive_ids.extend(batch)
+        drives = results.get("drives", [])
+        for d in drives:
+            did = d.get("id")
+            name = d.get("name")
+            if did:
+                drive_ids.append(did)
+                if name:
+                    drive_names.append(name)
         logger.info(
             "Retrieved %d drive ids (nextPageToken=%s)",
-            len(batch),
+            len(drives),
             results.get("nextPageToken"),
         )
         page = results.get("nextPageToken")
         if not page:
             break
 
-    logger.info("Total %d drive ids retrieved", len(drive_ids))
+    logger.info("Detected %d drives: %s", len(drive_names), ", ".join(drive_names))
     return drive_ids
 
 
@@ -152,7 +163,7 @@ def _list_drive_changes(
             "fields": (
                 "nextPageToken,newStartPageToken,"
                 "changes(removed,file(id,name,mimeType,modifiedTime,createdTime,"
-                "sharedWithMeTime,permissionIds))"
+                "sharedWithMeTime,permissionIds,driveId,capabilities(canRead,canComment)))"
             ),
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
@@ -241,7 +252,7 @@ def list_recent_docs(
         params = {
             "q": modified_query,
             "fields": (
-                "nextPageToken, files(id,name,modifiedTime,createdTime,sharedWithMeTime)"
+                "nextPageToken, files(id,name,driveId,capabilities(canRead,canComment),modifiedTime,createdTime,sharedWithMeTime)"
             ),
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
@@ -278,7 +289,7 @@ def list_recent_docs(
         if not has_access:
             info = (
                 service.files()
-                .get(fileId=fid, fields="id,capabilities(canRead,canComment)")
+                .get(fileId=fid, fields="id,driveId,capabilities(canRead,canComment)")
                 .execute(num_retries=3)
             )
             has_access = (
@@ -286,6 +297,8 @@ def list_recent_docs(
                 if isinstance(info, dict)
                 else False
             )
+            f["capabilities"] = info.get("capabilities", {})
+            f["driveId"] = info.get("driveId")
         if has_access:
             change_files_filtered.append(f)
     logger.info(
@@ -310,6 +323,14 @@ def list_recent_docs(
     for f in files_by_id.values():
         fid = f.get("id")
         name = f.get("name")
+        caps = f.get("capabilities", {})
+        logger.info(
+            "File %s driveId=%s canRead=%s canComment=%s",
+            fid,
+            f.get("driveId"),
+            caps.get("canRead"),
+            caps.get("canComment"),
+        )
         timestamps = {
             key: f.get(key)
             for key in ("modifiedTime", "createdTime", "sharedWithMeTime")
@@ -347,6 +368,8 @@ def list_recent_docs(
                 "Excluding file %s (%s): %s", fid, name, "; ".join(reasons)
             )
         else:
+            f.pop("capabilities", None)
+            f.pop("driveId", None)
             recent_files.append(f)
 
     logger.info("Returning %d documents after filtering", len(recent_files))

--- a/src/main.py
+++ b/src/main.py
@@ -181,6 +181,26 @@ def run_once(
     latest_time = since
     for f in files:
         latest_time = _latest_timestamp(f, latest_time)
+        fid = f.get("id")
+        drive_id = f.get("driveId")
+        caps = f.get("capabilities")
+        if fid and (drive_id is None or not isinstance(caps, dict)):
+            info = (
+                drive_service.files()
+                .get(fileId=fid, fields="driveId,capabilities(canRead,canComment)")
+                .execute(num_retries=3)
+            )
+            drive_id = info.get("driveId")
+            caps = info.get("capabilities", {})
+        can_read = caps.get("canRead") if isinstance(caps, dict) else None
+        can_comment = caps.get("canComment") if isinstance(caps, dict) else None
+        logger.info(
+            "File %s driveId=%s canRead=%s canComment=%s",
+            fid,
+            drive_id,
+            can_read,
+            can_comment,
+        )
         if _process_document(drive_service, docs_service, f):
             processed_count += 1
 

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -232,7 +232,7 @@ def test_list_recent_docs_skips_changes_without_service_permission():
     assert files == []
     assert tokens == {"user": "t1"}
     service.files.return_value.get.assert_called_once_with(
-        fileId="1", fields="id,capabilities(canRead,canComment)"
+        fileId="1", fields="id,driveId,capabilities(canRead,canComment)"
     )
 
 
@@ -280,7 +280,7 @@ def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
     ]
     assert tokens == {"user": "t1"}
     service.files.return_value.get.assert_called_once_with(
-        fileId="1", fields="id,capabilities(canRead,canComment)"
+        fileId="1", fields="id,driveId,capabilities(canRead,canComment)"
     )
 
 


### PR DESCRIPTION
## Summary
- Log service account email and permission ID when retrieved
- Report names and count of accessible drives
- Log each document's drive ID and read/comment capability during processing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6add8c4708328a8bdd192d1d2afc9