### PR TITLE
Eliminate unused canRead capability checks

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -163,7 +163,7 @@ def _list_drive_changes(
             "fields": (
                 "nextPageToken,newStartPageToken,"
                 "changes(removed,file(id,name,mimeType,modifiedTime,createdTime,"
-                "sharedWithMeTime,permissionIds,driveId,capabilities(canRead,canComment)))"
+                "sharedWithMeTime,permissionIds,driveId,capabilities(canComment)))"
             ),
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
@@ -252,7 +252,7 @@ def list_recent_docs(
         params = {
             "q": modified_query,
             "fields": (
-                "nextPageToken, files(id,name,driveId,capabilities(canRead,canComment),modifiedTime,createdTime,sharedWithMeTime)"
+                "nextPageToken, files(id,name,driveId,capabilities(canComment),modifiedTime,createdTime,sharedWithMeTime)"
             ),
             "supportsAllDrives": True,
             "includeItemsFromAllDrives": True,
@@ -289,11 +289,11 @@ def list_recent_docs(
         if not has_access:
             info = (
                 service.files()
-                .get(fileId=fid, fields="id,driveId,capabilities(canRead,canComment)")
+                .get(fileId=fid, fields="id,driveId,capabilities(canComment)")
                 .execute(num_retries=3)
             )
             has_access = (
-                info.get("capabilities", {}).get("canRead") is True
+                info.get("capabilities", {}).get("canComment") is True
                 if isinstance(info, dict)
                 else False
             )
@@ -325,10 +325,9 @@ def list_recent_docs(
         name = f.get("name")
         caps = f.get("capabilities", {})
         logger.info(
-            "File %s driveId=%s canRead=%s canComment=%s",
+            "File %s driveId=%s canComment=%s",
             fid,
             f.get("driveId"),
-            caps.get("canRead"),
             caps.get("canComment"),
         )
         timestamps = {

--- a/src/main.py
+++ b/src/main.py
@@ -187,18 +187,16 @@ def run_once(
         if fid and (drive_id is None or not isinstance(caps, dict)):
             info = (
                 drive_service.files()
-                .get(fileId=fid, fields="driveId,capabilities(canRead,canComment)")
+                .get(fileId=fid, fields="driveId,capabilities(canComment)")
                 .execute(num_retries=3)
             )
             drive_id = info.get("driveId")
             caps = info.get("capabilities", {})
-        can_read = caps.get("canRead") if isinstance(caps, dict) else None
         can_comment = caps.get("canComment") if isinstance(caps, dict) else None
         logger.info(
-            "File %s driveId=%s canRead=%s canComment=%s",
+            "File %s driveId=%s canComment=%s",
             fid,
             drive_id,
-            can_read,
             can_comment,
         )
         if _process_document(drive_service, docs_service, f):

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -225,14 +225,14 @@ def test_list_recent_docs_skips_changes_without_service_permission():
     }
     service.files.return_value.get.return_value.execute.return_value = {
         "id": "1",
-        "capabilities": {"canRead": False, "canComment": False},
+        "capabilities": {"canComment": False},
     }
     since = datetime(2024, 1, 1)
     files, tokens = list_recent_docs(service, since, {"user": "t0"})
     assert files == []
     assert tokens == {"user": "t1"}
     service.files.return_value.get.assert_called_once_with(
-        fileId="1", fields="id,driveId,capabilities(canRead,canComment)"
+        fileId="1", fields="id,driveId,capabilities(canComment)"
     )
 
 
@@ -262,7 +262,7 @@ def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
     }
     service.files.return_value.get.return_value.execute.return_value = {
         "id": "1",
-        "capabilities": {"canRead": True, "canComment": True},
+        "capabilities": {"canComment": True},
     }
 
     since = datetime(2024, 1, 1)
@@ -280,7 +280,7 @@ def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
     ]
     assert tokens == {"user": "t1"}
     service.files.return_value.get.assert_called_once_with(
-        fileId="1", fields="id,driveId,capabilities(canRead,canComment)"
+        fileId="1", fields="id,driveId,capabilities(canComment)"
     )
 
 


### PR DESCRIPTION
## Summary
- Simplify Drive change queries to only request `capabilities(canComment)`
- Drop `canRead` checks and log only comment capability
- Update tests for `capabilities(canComment)`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6b2e474cc8328a67e27387e858267