### PR TITLE
Ensure Drive API scans all shared and personal drives

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -122,14 +122,20 @@ def list_all_shared_docs(service: Any) -> list[dict[str, Any]]:
             "fields": (
                 "nextPageToken, files(id,name,modifiedTime,createdTime,sharedWithMeTime)"
             ),
-            "supportsAllDrives": True,
-            "includeItemsFromAllDrives": True,
             "corpora": "allDrives",
             "pageSize": 1000,
         }
         if page:
             params["pageToken"] = page
-        results = service.files().list(**params).execute(num_retries=3)
+        results = (
+            service.files()
+            .list(
+                **params,
+                supportsAllDrives=True,
+                includeItemsFromAllDrives=True,
+            )
+            .execute(num_retries=3)
+        )
         batch = results.get("files", [])
         files.extend(batch)
         logger.info(


### PR DESCRIPTION
## Summary
- Pass `supportsAllDrives` and `includeItemsFromAllDrives` flags when listing shared docs so Drive queries include all personal and shared drives

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6d7b3c0348328a96879c0c305cc19