### PR TITLE
Refresh Drive change token on HTTP 410

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -6,6 +6,8 @@ import json
 import logging
 from typing import Any
 
+from googleapiclient.errors import HttpError
+
 from .google_service import build_service
 from .time_utils import parse_google_timestamp
 
@@ -181,7 +183,24 @@ def _list_drive_changes(
         }
         if drive_id:
             params["driveId"] = drive_id
-        results = service.changes().list(**params).execute(num_retries=3)
+        try:
+            results = service.changes().list(**params).execute(num_retries=3)
+        except HttpError as e:
+            status = getattr(getattr(e, "resp", None), "status", None)
+            if status == 410:
+                logger.info("Change token expired; fetching a fresh start token")
+                gsp_params = {"supportsAllDrives": True}
+                if drive_id:
+                    gsp_params["driveId"] = drive_id
+                token = (
+                    service.changes()
+                    .getStartPageToken(**gsp_params)
+                    .execute(num_retries=3)
+                    .get("startPageToken", token)
+                )
+                logger.info("Retrying changes.list with refreshed token %s", token)
+                continue
+            raise
         changes = results.get("changes", [])
         logger.info(
             "Retrieved %d change records (nextPageToken=%s)",

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -191,3 +191,37 @@ def test_reshared_docs_are_reprocessed(monkeypatch, tmp_path):
 
     with open(cache.path) as f:
         assert json.load(f) == ["1"]
+
+
+def test_run_once_refreshes_token_on_410(monkeypatch, tmp_path):
+    drive = MagicMock()
+    docs = MagicMock()
+
+    # Permission ID for _get_permission_id
+    drive.about.return_value.get.return_value.execute.return_value = {
+        "user": {"permissionId": "pid"}
+    }
+    # No modified documents
+    drive.files.return_value.list.return_value.execute.return_value = {"files": []}
+
+    from googleapiclient.errors import HttpError
+    from httplib2 import Response
+
+    error = HttpError(Response({"status": 410}), b"{}")
+    drive.changes.return_value.list.return_value.execute.side_effect = [
+        error,
+        {"changes": [], "newStartPageToken": "t1"},
+    ]
+    drive.changes.return_value.getStartPageToken.return_value.execute.return_value = {
+        "startPageToken": "fresh"
+    }
+
+    monkeypatch.setattr("src.main.list_all_shared_docs", lambda svc: [])
+
+    cache = DocumentCache(tmp_path / "cache.json")
+    since = datetime.utcnow()
+    _, tokens = run_once(drive, docs, since, {"user": "old"}, cache)
+
+    assert tokens == {"user": "t1"}
+    assert drive.changes.return_value.list.call_count == 2
+    assert drive.changes.return_value.getStartPageToken.call_count == 1


### PR DESCRIPTION
## Summary
- handle expired Drive change tokens by fetching a fresh start page token and retrying
- test runner retry logic when Google Drive changes.list returns HTTP 410

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e4507b988328a71cbf3a14196c82