### PR TITLE
Include new drives in change tracking

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -239,11 +239,26 @@ def list_recent_changes_all(
 
     all_files: list[dict[str, Any]] = []
     new_tokens: dict[str, str] = {}
-    for key, token in page_tokens.items():
+
+    # Discover any new shared drives each cycle
+    for drive_id in list_all_drive_ids(service):
+        if drive_id not in page_tokens:
+            token = (
+                service.changes()
+                    .getStartPageToken(
+                        driveId=drive_id, supportsAllDrives=True
+                    )
+                    .execute(num_retries=3)
+                    .get("startPageToken", "")
+            )
+            page_tokens[drive_id] = token
+
+    for key, token in list(page_tokens.items()):
         drive_id = None if key == "user" else key
         files, new_token = _list_drive_changes(service, token, drive_id)
         all_files.extend(files)
         new_tokens[key] = new_token
+
     return all_files, new_tokens
 
 

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -1,7 +1,7 @@
 """Tests for Google Drive helpers including document listing, properties, comments, and revisions."""
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 import pytest
 import json
 
@@ -9,6 +9,7 @@ from src.google_drive import (
     download_revision_text,
     get_share_message,
     get_app_properties,
+    list_recent_changes_all,
     list_recent_docs,
     list_all_shared_docs,
     reply_to_comment,
@@ -262,6 +263,48 @@ def test_list_recent_docs_skips_changes_without_service_permission():
     service.files.return_value.get.assert_called_once_with(
         fileId="1", fields="id,driveId,capabilities(canComment)"
     )
+
+
+def test_list_recent_changes_all_discovers_new_drive(monkeypatch):
+    service = MagicMock()
+    drive_ids = iter([[], ["d1"]])
+    monkeypatch.setattr(
+        "src.google_drive.list_all_drive_ids",
+        lambda s: next(drive_ids),
+    )
+
+    service.changes.return_value.getStartPageToken.return_value.execute.side_effect = [
+        {"startPageToken": "d0"}
+    ]
+
+    returns = [
+        ([], "u1"),
+        ([], "u2"),
+        ([{"id": "f1"}], "d1t1"),
+    ]
+
+    def list_changes_side_effect(svc, token, drive_id):
+        return returns.pop(0)
+
+    list_changes_mock = MagicMock(side_effect=list_changes_side_effect)
+    monkeypatch.setattr("src.google_drive._list_drive_changes", list_changes_mock)
+
+    files1, tokens1 = list_recent_changes_all(service, {"user": "u0"})
+    assert files1 == []
+    assert tokens1 == {"user": "u1"}
+
+    files2, tokens2 = list_recent_changes_all(service, tokens1)
+    assert files2 == [{"id": "f1"}]
+    assert tokens2 == {"user": "u2", "d1": "d1t1"}
+
+    service.changes.return_value.getStartPageToken.assert_called_once_with(
+        driveId="d1", supportsAllDrives=True
+    )
+    assert list_changes_mock.call_args_list == [
+        call(service, "u0", None),
+        call(service, "u1", None),
+        call(service, "d0", "d1"),
+    ]
 
 
 def test_list_recent_docs_includes_doc_reshared_without_permission_ids():


### PR DESCRIPTION
## Summary
- detect newly available shared drives on each cycle and initialize their change tokens
- ensure new drives' change tokens are persisted for future runs
- add regression test for drive discovery mid-run

## Testing
- `pytest -q` *(fails: Killed)*
- `pytest -q test/test_google_drive.py::test_list_recent_changes_all_discovers_new_drive -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e7814c208328b1ca222838e06329