### PR TITLE
Retry failed document reviews

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -179,6 +179,8 @@ def run_once(
 
     processed_count = 0
     latest_time = since
+    processed_ids: set[str] = set()
+    successful_ids: set[str] = set()
     for f in files:
         latest_time = _latest_timestamp(f, latest_time)
         fid = f.get("id")
@@ -199,8 +201,10 @@ def run_once(
             drive_id,
             can_comment,
         )
+        processed_ids.add(fid)
         if _process_document(drive_service, docs_service, f):
             processed_count += 1
+            successful_ids.add(fid)
 
     logger.info(
         "Completed review cycle. Successfully processed %d/%d documents",
@@ -208,7 +212,10 @@ def run_once(
         len(files),
     )
 
-    cache.ids = current_ids
+    failed_ids = processed_ids - successful_ids
+    cache.ids.intersection_update(current_ids)
+    cache.ids.difference_update(failed_ids)
+    cache.ids.update(successful_ids)
     cache.save()
 
     new_timestamp = max(latest_time, datetime.utcnow())

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -193,6 +193,36 @@ def test_reshared_docs_are_reprocessed(monkeypatch, tmp_path):
         assert json.load(f) == ["1"]
 
 
+def test_failed_docs_are_reprocessed(monkeypatch, tmp_path):
+    drive = MagicMock()
+    docs = MagicMock()
+    cache = DocumentCache(tmp_path / "cache.json")
+
+    monkeypatch.setattr("src.main.list_all_shared_docs", lambda svc: [{"id": "1"}])
+    monkeypatch.setattr(
+        "src.main.list_recent_docs", lambda svc, since, tokens: ([], tokens)
+    )
+
+    calls: list[str] = []
+
+    def fake_process(drive_service, docs_service, file):
+        calls.append(file["id"])
+        return len(calls) > 1
+
+    monkeypatch.setattr("src.main._process_document", fake_process)
+
+    since = datetime.utcnow()
+    tokens: dict[str, str] = {}
+
+    since, tokens = run_once(drive, docs, since, tokens, cache)
+    assert calls == ["1"]
+    assert cache.ids == set()
+
+    since, tokens = run_once(drive, docs, since, tokens, cache)
+    assert calls == ["1", "1"]
+    assert cache.ids == {"1"}
+
+
 def test_run_once_refreshes_token_on_410(monkeypatch, tmp_path):
     drive = MagicMock()
     docs = MagicMock()


### PR DESCRIPTION
## Summary
- Track document IDs that were processed successfully
- Update document cache with successful IDs and remove failed or unshared docs
- Add regression test ensuring failed documents are retried

## Testing
- `pytest -q test/test_google_docs.py`
- `pytest -q test/test_google_drive.py`
- `pytest -q test/test_groq_client.py`
- `pytest -q test/test_review.py`
- `pytest -q test/test_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6eb04b63483289676913305224955