### PR TITLE
Switch Google API auth to OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ People often wonder if AI will replace white-collar workers, but what if it coul
 ### How it works
 
 * Draft a report or proposal in Google Docs.
-* Share it with the service account before sending it to your boss.
+* Authorize the app with your Google account and edit as usual.
 * Get quick, boss-style comments to tidy up your work early.
 
 ---
 
 ## 🎯 Objective
 
-Provide an autonomous **"boss" reviewer** that acts like your manager: it reviews documents shared with a service account and offers direct, helpful feedback without human involvement.
+Provide an autonomous **"boss" reviewer** that acts like your manager: it reviews documents in your Google Drive and offers direct, helpful feedback without human involvement.
 
 ---
 
@@ -93,14 +93,15 @@ Environment variables are loaded from `.env`:
 | Variable                      | Description |
 | ----------------------------- | ------------------------------------------------------------------------------------ |
 | `GROQ_API_KEY`                | Groq API token |
-| `GOOGLE_SERVICE_ACCOUNT_JSON` | Path to service account credentials with permission to comment on shared Docs |
+| `GOOGLE_OAUTH_CLIENT_SECRET_JSON` | Path to OAuth client secret JSON downloaded from Google Cloud |
+| `GOOGLE_OAUTH_TOKEN_JSON`     | Path to store the OAuth token retrieved after consent |
 | `GROQ_CHUNK_SIZE`             | Max bytes per request to Groq (default `20000`) |
 | `GROQ_REQUESTS_PER_MINUTE`    | Requests per minute before throttling (default `10`) |
 ---
 
 ## ▶️ Running
 
-Share or edit a Google Doc with the service account in your credentials (it must have permission to comment). Optional: add background context in the file's **Description** field so the reviewer understands the goal.
+Edit a Google Doc in your Drive and let the authorized app read it. Optional: add background context in the file's **Description** field so the reviewer understands the goal.
 
 ```bash
 pip install -r requirements.txt

--- a/config/settings.py
+++ b/config/settings.py
@@ -4,7 +4,8 @@ import os
 load_dotenv()
 
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
-GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
+GOOGLE_OAUTH_CLIENT_SECRET_JSON = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET_JSON")
+GOOGLE_OAUTH_TOKEN_JSON = os.getenv("GOOGLE_OAUTH_TOKEN_JSON")
 GROQ_CHUNK_SIZE = int(os.getenv("GROQ_CHUNK_SIZE", 20000))
 # Default to Groq's published rate limit of 10 requests per minute
 GROQ_REQUESTS_PER_MINUTE = int(os.getenv("GROQ_REQUESTS_PER_MINUTE", 10))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask
 google-api-python-client
+google-auth-oauthlib
 groq
 python-dotenv
 requests

--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -22,19 +22,19 @@ def build_drive_service() -> Any:
 
 
 def _get_permission_id(service: Any) -> str:
-    """Return the Drive permission ID for the authenticated service account."""
+    """Return the Drive permission ID for the authenticated account."""
     about = (
         service.about()
         .get(fields="user(permissionId)")
         .execute(num_retries=3)
     )
     perm_id = about.get("user", {}).get("permissionId", "")
-    logger.info("Service account permission ID: %s", perm_id)
+    logger.info("Account permission ID: %s", perm_id)
     return perm_id
 
 
 def list_all_drive_ids(service: Any) -> list[str]:
-    """Return IDs for all shared drives accessible to the service account."""
+    """Return IDs for all shared drives accessible to the authenticated account."""
     logger.info("Listing all accessible drive IDs")
     drive_ids: list[str] = []
     drive_names: list[str] = []
@@ -90,11 +90,11 @@ def get_start_page_tokens(service: Any) -> dict[str, str]:
 
 
 def list_all_shared_docs(service: Any) -> list[dict[str, Any]]:
-    """Return all Google Docs currently shared with the service account.
+    """Return all Google Docs currently shared with the authenticated account.
 
-    For service accounts, 'sharedWithMe=true' doesn't work as expected.
-    Instead, we query for documents that the service account can comment on,
-    which indicates they have been shared with the service account.
+    Historically, service accounts could not rely on ``sharedWithMe=true``.
+    We therefore query for documents that the account can comment on, which
+    also works for standard user credentials.
 
     Parameters
     ----------
@@ -130,8 +130,8 @@ def list_all_shared_docs(service: Any) -> list[dict[str, Any]]:
             .execute(num_retries=3)
         )
         batch = results.get("files", [])
-        # Filter for documents where the service account can comment 
-        # (indicating they have been shared with the service account)
+        # Filter for documents where the authenticated account can comment
+        # (indicating they have been shared with that account)
         filtered_batch = []
         for doc in batch:
             capabilities = doc.get("capabilities", {})

--- a/src/google_service.py
+++ b/src/google_service.py
@@ -5,14 +5,20 @@ from __future__ import annotations
 from typing import Any
 import os
 
-from google.oauth2 import service_account
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
 from config import settings
 
 
 def build_service(api: str, version: str, scopes: list[str]) -> Any:
-    """Create an authenticated Google API client for ``api``.
+    """Create an authenticated Google API client for ``api`` using OAuth.
+
+    The client secret and token storage paths are configured via the
+    ``GOOGLE_OAUTH_CLIENT_SECRET_JSON`` and ``GOOGLE_OAUTH_TOKEN_JSON``
+    environment variables respectively.
 
     Parameters
     ----------
@@ -26,22 +32,39 @@ def build_service(api: str, version: str, scopes: list[str]) -> Any:
     Raises
     ------
     ValueError
-        If the ``GOOGLE_SERVICE_ACCOUNT_JSON`` setting is not configured.
+        If either credential environment variable is not configured.
     FileNotFoundError
-        If the credential file does not exist.
+        If the client secret file does not exist.
     """
 
-    cred_path = settings.GOOGLE_SERVICE_ACCOUNT_JSON
-    if not cred_path:
+    client_secret_path = settings.GOOGLE_OAUTH_CLIENT_SECRET_JSON
+    token_path = settings.GOOGLE_OAUTH_TOKEN_JSON
+    if not client_secret_path:
         raise ValueError(
-            "GOOGLE_SERVICE_ACCOUNT_JSON environment variable is not set."
+            "GOOGLE_OAUTH_CLIENT_SECRET_JSON environment variable is not set."
         )
-    if not os.path.exists(cred_path):
+    if not token_path:
+        raise ValueError(
+            "GOOGLE_OAUTH_TOKEN_JSON environment variable is not set."
+        )
+    if not os.path.exists(client_secret_path):
         raise FileNotFoundError(
-            f"Service account JSON file not found at {cred_path}"
+            f"OAuth client secret JSON file not found at {client_secret_path}"
         )
 
-    creds = service_account.Credentials.from_service_account_file(
-        cred_path, scopes=scopes
-    )
+    creds: Credentials | None = None
+    if os.path.exists(token_path):
+        creds = Credentials.from_authorized_user_file(token_path, scopes)
+
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                client_secret_path, scopes
+            )
+            creds = flow.run_local_server(port=0)
+        with open(token_path, "w") as token_file:
+            token_file.write(creds.to_json())
+
     return build(api, version, credentials=creds)

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -74,6 +74,9 @@ def test_list_recent_docs_filters_by_time():
         "changes": [],
         "newStartPageToken": "t1",
     }
+    service.drives.return_value.list.return_value.execute.return_value = {
+        "drives": []
+    }
 
     since = datetime(2023, 12, 31, 23, 0, 0)
     files, tokens = list_recent_docs(service, since, {"user": "t0"})
@@ -107,6 +110,9 @@ def test_list_recent_docs_includes_newly_shared_docs():
             }
         ],
         "newStartPageToken": "t1",
+    }
+    service.drives.return_value.list.return_value.execute.return_value = {
+        "drives": []
     }
 
     since = datetime(2024, 1, 1, 12, 0, 0)
@@ -147,6 +153,9 @@ def test_list_recent_docs_parses_microsecond_timestamps():
         ],
         "newStartPageToken": "t1",
     }
+    service.drives.return_value.list.return_value.execute.return_value = {
+        "drives": []
+    }
     since = datetime(2024, 1, 1, 23, 59, 59)
     files, _ = list_recent_docs(service, since, {"user": "t0"})
     assert {f["name"] for f in files} == {"Micro", "CreatedMicro"}
@@ -181,6 +190,7 @@ def test_list_recent_docs_handles_pagination():
 
     service.files.return_value.list.return_value.execute.side_effect = file_pages
     service.changes.return_value.list.return_value.execute.side_effect = change_pages
+    service.drives.return_value.list.return_value.execute.return_value = {"drives": []}
 
     since = datetime(2024, 1, 1, 12, 0, 0)
     files, tokens = list_recent_docs(service, since, {"user": "c0"})
@@ -219,6 +229,9 @@ def test_list_recent_docs_detects_permission_changes_without_shared_time():
         ],
         "newStartPageToken": "t1",
     }
+    service.drives.return_value.list.return_value.execute.return_value = {
+        "drives": []
+    }
 
     since = datetime(2024, 1, 1, 0, 0, 0)
     files, _ = list_recent_docs(service, since, {"user": "t0"})
@@ -255,6 +268,9 @@ def test_list_recent_docs_skips_changes_without_service_permission():
     service.files.return_value.get.return_value.execute.return_value = {
         "id": "1",
         "capabilities": {"canComment": False},
+    }
+    service.drives.return_value.list.return_value.execute.return_value = {
+        "drives": []
     }
     since = datetime(2024, 1, 1)
     files, tokens = list_recent_docs(service, since, {"user": "t0"})
@@ -334,6 +350,9 @@ def test_list_recent_docs_includes_doc_reshared_without_permission_ids():
     service.files.return_value.get.return_value.execute.return_value = {
         "id": "1",
         "capabilities": {"canComment": True},
+    }
+    service.drives.return_value.list.return_value.execute.return_value = {
+        "drives": []
     }
 
     since = datetime(2024, 1, 1)
@@ -433,12 +452,50 @@ def test_list_comments_and_replies():
 
 
 def test_build_drive_service_missing_credentials(monkeypatch):
-    """Should raise a clear error when credential path is not configured."""
+    """Should raise a clear error when client secret path is not configured."""
     monkeypatch.setattr(
-        "src.google_service.settings.GOOGLE_SERVICE_ACCOUNT_JSON", None
+        "src.google_service.settings.GOOGLE_OAUTH_CLIENT_SECRET_JSON", None
+    )
+    monkeypatch.setattr(
+        "src.google_service.settings.GOOGLE_OAUTH_TOKEN_JSON", "/tmp/token.json"
     )
     with pytest.raises(ValueError):
         build_drive_service()
+
+
+def test_build_drive_service_uses_saved_token(monkeypatch, tmp_path):
+    """When a token file exists, credentials should load without running flow."""
+    client = tmp_path / "client.json"
+    token = tmp_path / "token.json"
+    client.write_text("{}")
+    token.write_text("{}")
+
+    creds = MagicMock(valid=True)
+    monkeypatch.setattr(
+        "src.google_service.Credentials.from_authorized_user_file",
+        lambda path, scopes: creds,
+    )
+    build_mock = MagicMock()
+    monkeypatch.setattr("src.google_service.build", build_mock)
+    flow_mock = MagicMock()
+    monkeypatch.setattr(
+        "src.google_service.InstalledAppFlow.from_client_secrets_file", flow_mock
+    )
+
+    monkeypatch.setattr(
+        "src.google_service.settings.GOOGLE_OAUTH_CLIENT_SECRET_JSON",
+        str(client),
+    )
+    monkeypatch.setattr(
+        "src.google_service.settings.GOOGLE_OAUTH_TOKEN_JSON",
+        str(token),
+    )
+
+    service = build_drive_service()
+
+    build_mock.assert_called_once_with("drive", "v3", credentials=creds)
+    assert service is build_mock.return_value
+    flow_mock.assert_not_called()
 
 def test_create_comment_calls_api(region):
     service = MagicMock()

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -245,6 +245,7 @@ def test_run_once_refreshes_token_on_410(monkeypatch, tmp_path):
     drive.changes.return_value.getStartPageToken.return_value.execute.return_value = {
         "startPageToken": "fresh"
     }
+    drive.drives.return_value.list.return_value.execute.return_value = {"drives": []}
 
     monkeypatch.setattr("src.main.list_all_shared_docs", lambda svc: [])
 


### PR DESCRIPTION
## Summary
- switch Google API client creation from service account credentials to OAuth using InstalledAppFlow
- persist OAuth tokens and document new environment variables for client secret and token paths
- update tests to mock OAuth credentials and Drive responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7bd117a60832885d60f30da47b6b7