### PR TITLE
Use segment-based anchors for Drive comments

### DIFF
--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -476,7 +476,22 @@ def create_comment(
     revision_id: str = "head",
     regions: list[dict] | None = None,
 ) -> dict[str, str]:
-    """Create a comment on ``file_id`` optionally anchored to a text range."""
+    """Create a comment on ``file_id`` optionally anchored to a text range.
+
+    Parameters
+    ----------
+    service: Any
+        Authenticated Drive API service.
+    file_id: str
+        ID of the document to comment on.
+    content: str
+        Comment text.
+    revision_id: str, optional
+        Target revision ID for anchoring, defaults to ``"head"``.
+    regions: list[dict] | None, optional
+        List of segment dictionaries each with ``startIndex`` and ``endIndex``
+        character offsets identifying the text span to anchor.
+    """
     body: dict[str, Any] = {"content": content}
     anchor_dict: dict[str, Any] = {"r": revision_id}
     if regions is not None:

--- a/src/review.py
+++ b/src/review.py
@@ -258,8 +258,6 @@ def post_comments(
     """
 
     MAX_BYTES = 4096
-    # Retrieve plain text of the latest revision so we can derive line numbers
-    document_text = download_revision_text(drive_service, document_id, "head")
 
     for item in items:
         lines: list[str] = []
@@ -274,10 +272,7 @@ def post_comments(
         end = item.get("end_index")
         regions = None
         if start is not None and end is not None:
-            start_line = document_text.count("\n", 0, start) + 1
-            end_line = document_text.count("\n", 0, max(end - 1, 0)) + 1
-            line_count = end_line - start_line + 1
-            regions = [{"line": {"n": start_line, "l": line_count}}]
+            regions = [{"segment": {"startIndex": start, "endIndex": end}}]
         try:
             comment = _retry_with_backoff(
                 create_comment,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,10 +1,12 @@
 import pytest
 
-def make_region(n: int = 1, l: int = 1) -> dict:
-    """Return a simple line-based region object for tests."""
-    return {"line": {"n": n, "l": l}}
+
+def make_region(start: int = 0, end: int = 1) -> dict:
+    """Return a simple segment-based region object for tests."""
+    return {"segment": {"startIndex": start, "endIndex": end}}
+
 
 @pytest.fixture
 def region() -> dict:
-    """Default region representing the first line."""
+    """Default region representing the first character."""
     return make_region()

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -502,9 +502,12 @@ def test_create_comment_calls_api(region):
     service.comments.return_value.create.return_value.execute.return_value = {"id": "c1"}
     result = create_comment(service, "doc", "hello", regions=[region])
     assert result == {"id": "c1"}
+    expected_anchor = json.dumps(
+        {"r": "head", "a": [{"segment": {"startIndex": 0, "endIndex": 1}}]}
+    )
     body = {
         "content": "hello",
-        "anchor": json.dumps({"r": "head", "a": [region]}),
+        "anchor": expected_anchor,
     }
     service.comments.return_value.create.assert_called_once_with(
         fileId="doc", body=body, fields="id"

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -190,7 +190,7 @@ def test_review_document_ignores_empty_suggestions():
     assert update_body["appProperties"]["suggestionHashes"] == "abcd"
 
 
-def test_post_comments_calls_create(monkeypatch, region):
+def test_post_comments_calls_create(monkeypatch):
     create_calls = []
     reply_calls = []
 
@@ -216,7 +216,8 @@ def test_post_comments_calls_create(monkeypatch, region):
         }
     ]
     post_comments("drive", "doc1", items)
-    assert create_calls == [("doc1", "Fix typo", "head", [region])]
+    expected_region = {"segment": {"startIndex": 1, "endIndex": 3}}
+    assert create_calls == [("doc1", "Fix typo", "head", [expected_region])]
     assert reply_calls == []
 
 


### PR DESCRIPTION
## Summary
- Anchor review comments using character offsets instead of line numbers
- Serialize segment ranges when creating Drive comments
- Update tests to expect segment-based regions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7d1d7516883288c60c340b090e62b