### PR TITLE
Use Docs named ranges for Drive comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ Provide an autonomous **"boss" reviewer** that acts like your manager: it review
 * 🚀 **Drive & Docs integration** – Polls Google Drive for modified or newly shared docs and retrieves paragraph text.
 * 🔍 **Change tracking** – Detects changes by comparing the latest revision with the last reviewed version.
 * 🤖 **LLM suggestions** – Sends edited text to Groq's Chat Completions API with chunking, retries, and rate limiting.
-* 💬 **Automated comments** – Uses the Google Drive API to anchor comments at precise text offsets.
+* 💬 **Automated comments** – Drive comments can't directly anchor to text, so the
+  reviewer creates Docs *named ranges* and references them in each comment,
+  optionally inserting a tiny "🔗" link target inside the document for easy
+  navigation.
 * 📝 **Context-aware feedback** – Treats a document's description as extra context for the reviewer.
 * ♻️ **Revision-aware deduplication** – Stores the last reviewed revision and hashed suggestions in Drive `appProperties` to skip repeated comments.
 * ⏱ **Scheduled runner** – Runs `main.py` periodically using the `schedule` library.

--- a/src/google_docs.py
+++ b/src/google_docs.py
@@ -5,7 +5,8 @@ from typing import Any
 
 from .google_service import build_service
 
-SCOPES = ["https://www.googleapis.com/auth/documents.readonly"]
+# Full Docs scope is required for creating named ranges and inserting markers.
+SCOPES = ["https://www.googleapis.com/auth/documents"]
 
 
 def build_docs_service() -> Any:
@@ -55,3 +56,75 @@ def chunk_paragraphs(paragraphs: list[str], max_chars: int) -> list[str]:
     if current:
         chunks.append("\n".join(current))
     return chunks
+
+
+def create_named_range(
+    service: Any,
+    document_id: str,
+    name: str,
+    start_index: int,
+    end_index: int,
+    link_marker: bool = True,
+) -> str:
+    """Create a named range and optionally insert a linked "🔗" marker.
+
+    Parameters
+    ----------
+    service: Any
+        Authenticated Docs API service.
+    document_id: str
+        ID of the document to update.
+    name: str
+        Human-friendly label for the range.
+    start_index, end_index: int
+        Character offsets that define the range.
+    link_marker: bool, optional
+        When ``True`` (default) a "🔗" character linked to the range is
+        inserted after ``end_index`` so readers can jump to the span.
+    Returns
+    -------
+    str
+        The ``namedRangeId`` assigned by the Docs API.
+    """
+
+    requests = [
+        {
+            "createNamedRange": {
+                "name": name,
+                "range": {"startIndex": start_index, "endIndex": end_index},
+            }
+        }
+    ]
+    result = (
+        service.documents()
+        .batchUpdate(documentId=document_id, body={"requests": requests})
+        .execute(num_retries=3)
+    )
+    named_range_id = (
+        result.get("replies", [{}])[0]
+        .get("createNamedRange", {})
+        .get("namedRangeId", "")
+    )
+
+    if link_marker and named_range_id:
+        marker = "🔗"
+        # Emoji use two UTF-16 code units in Docs indexes
+        marker_len = 2
+        marker_requests = [
+            {"insertText": {"location": {"index": end_index}, "text": marker}},
+            {
+                "updateTextStyle": {
+                    "range": {
+                        "startIndex": end_index,
+                        "endIndex": end_index + marker_len,
+                    },
+                    "textStyle": {"link": {"bookmarkId": named_range_id}},
+                    "fields": "link",
+                }
+            },
+        ]
+        service.documents().batchUpdate(
+            documentId=document_id, body={"requests": marker_requests}
+        ).execute(num_retries=3)
+
+    return named_range_id

--- a/src/google_drive.py
+++ b/src/google_drive.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-import json
 import logging
 from typing import Any
 
@@ -480,10 +479,10 @@ def create_comment(
     service: Any,
     file_id: str,
     content: str,
-    revision_id: str = "head",
-    regions: list[dict] | None = None,
+    quote: str,
+    ref: str,
 ) -> dict[str, str]:
-    """Create a comment on ``file_id`` optionally anchored to a text range.
+    """Create a comment on ``file_id`` referencing a named range.
 
     Parameters
     ----------
@@ -493,17 +492,15 @@ def create_comment(
         ID of the document to comment on.
     content: str
         Comment text.
-    revision_id: str, optional
-        Target revision ID for anchoring, defaults to ``"head"``.
-    regions: list[dict] | None, optional
-        List of segment dictionaries each with ``startIndex`` and ``endIndex``
-        character offsets identifying the text span to anchor.
+    quote: str
+        Quoted text to display in the comment.
+    ref: str
+        Named range identifier or link label.
     """
-    body: dict[str, Any] = {"content": content}
-    anchor_dict: dict[str, Any] = {"r": revision_id}
-    if regions is not None:
-        anchor_dict["a"] = regions
-    body["anchor"] = json.dumps(anchor_dict)
+    body: dict[str, Any] = {
+        "content": f"{content}\n@NR:{ref}" if ref else content,
+        "quotedFileContent": {"value": quote, "mimeType": "text/plain"},
+    }
     return (
         service.comments()
         .create(fileId=file_id, body=body, fields="id")

--- a/src/main.py
+++ b/src/main.py
@@ -92,7 +92,7 @@ def _process_document(
         )
 
         if items:
-            post_comments(drive_service, doc_id, items)
+            post_comments(drive_service, docs_service, doc_id, items)
             logger.info(
                 "Posted %d comments to document '%s'", len(items), doc_name
             )

--- a/src/review.py
+++ b/src/review.py
@@ -13,7 +13,7 @@ import time
 from difflib import SequenceMatcher
 from googleapiclient.errors import HttpError
 
-from .google_docs import chunk_paragraphs, get_document_paragraphs
+from .google_docs import chunk_paragraphs, get_document_paragraphs, create_named_range
 from .google_drive import (
     download_revision_text,
     get_app_properties,
@@ -245,16 +245,17 @@ def review_document(
 
 def post_comments(
     drive_service: Any,
+    docs_service: Any,
     document_id: str,
     items: list[dict[str, str]],
 ) -> None:
     """Post review items as comments on the document.
 
-    Comments contain only AI-generated feedback and are anchored to the
-    relevant text range. If a comment exceeds the 4096 byte limit imposed by
-    the Google Drive API, it is split into multiple parts. The first part is
-    posted as a comment anchored to the text range; subsequent parts are added
-    as replies to the first comment.
+    Comments contain only AI-generated feedback and reference named ranges
+    created in the document. If a comment exceeds the 4096 byte limit imposed
+    by the Google Drive API, it is split into multiple parts. The first part is
+    posted as a comment; subsequent parts are added as replies to the first
+    comment.
     """
 
     MAX_BYTES = 4096
@@ -267,20 +268,31 @@ def post_comments(
         lines.append(item.get("suggestion", ""))
         content = "\n".join(lines)
         parts = split_into_byte_chunks(content, MAX_BYTES)
-        # Post the first part anchored to the text range
+
         start = item.get("start_index")
         end = item.get("end_index")
-        regions = None
+        range_id = ""
         if start is not None and end is not None:
-            regions = [{"segment": {"startIndex": start, "endIndex": end}}]
+            try:
+                range_id = _retry_with_backoff(
+                    create_named_range,
+                    docs_service,
+                    document_id,
+                    item.get("hash", f"range-{start}-{end}"),
+                    start,
+                    end,
+                )
+            except Exception:
+                logging.exception("Failed to create named range for %s", document_id)
+
         try:
             comment = _retry_with_backoff(
                 create_comment,
                 drive_service,
                 document_id,
                 parts[0],
-                revision_id="head",
-                regions=regions,
+                quote=item.get("quote", ""),
+                ref=range_id,
             )
         except Exception:
             logging.exception("Failed to create comment for %s", document_id)

--- a/test/test_google_docs.py
+++ b/test/test_google_docs.py
@@ -1,6 +1,10 @@
 from unittest.mock import MagicMock
 
-from src.google_docs import get_document_paragraphs, chunk_paragraphs
+from src.google_docs import (
+    get_document_paragraphs,
+    chunk_paragraphs,
+    create_named_range,
+)
 
 
 def test_get_document_paragraphs():
@@ -21,3 +25,28 @@ def test_chunk_paragraphs():
     paragraphs = ["a" * 10, "b" * 10, "c" * 10]
     chunks = chunk_paragraphs(paragraphs, max_chars=25)
     assert chunks == ["a" * 10 + "\n" + "b" * 10, "c" * 10]
+
+
+def test_create_named_range_inserts_marker():
+    service = MagicMock()
+    service.documents.return_value.batchUpdate.return_value.execute.side_effect = [
+        {"replies": [{"createNamedRange": {"namedRangeId": "nr1"}}]},
+        {},
+    ]
+    range_id = create_named_range(service, "doc", "label", 1, 2)
+    assert range_id == "nr1"
+    batch_calls = service.documents.return_value.batchUpdate.call_args_list
+    assert batch_calls[0].kwargs == {
+        "documentId": "doc",
+        "body": {
+            "requests": [
+                {
+                    "createNamedRange": {
+                        "name": "label",
+                        "range": {"startIndex": 1, "endIndex": 2},
+                    }
+                }
+            ]
+        },
+    }
+    assert batch_calls[1].kwargs["documentId"] == "doc"

--- a/test/test_google_drive.py
+++ b/test/test_google_drive.py
@@ -3,7 +3,6 @@
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, call
 import pytest
-import json
 
 from src.google_drive import (
     download_revision_text,
@@ -533,17 +532,16 @@ def test_build_drive_service_uses_saved_token(monkeypatch, tmp_path):
     assert service is build_mock.return_value
     flow_mock.assert_not_called()
 
-def test_create_comment_calls_api(region):
+def test_create_comment_calls_api():
     service = MagicMock()
-    service.comments.return_value.create.return_value.execute.return_value = {"id": "c1"}
-    result = create_comment(service, "doc", "hello", regions=[region])
+    service.comments.return_value.create.return_value.execute.return_value = {
+        "id": "c1"
+    }
+    result = create_comment(service, "doc", "hello", "quote", "nr1")
     assert result == {"id": "c1"}
-    expected_anchor = json.dumps(
-        {"r": "head", "a": [{"segment": {"startIndex": 0, "endIndex": 1}}]}
-    )
     body = {
-        "content": "hello",
-        "anchor": expected_anchor,
+        "content": "hello\n@NR:nr1",
+        "quotedFileContent": {"value": "quote", "mimeType": "text/plain"},
     }
     service.comments.return_value.create.assert_called_once_with(
         fileId="doc", body=body, fields="id"

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -193,14 +193,20 @@ def test_review_document_ignores_empty_suggestions():
 def test_post_comments_calls_create(monkeypatch):
     create_calls = []
     reply_calls = []
+    range_calls = []
 
-    def fake_create(service, file_id, content, revision_id="head", regions=None):
-        create_calls.append((file_id, content, revision_id, regions))
+    def fake_range(service, doc_id, name, start, end, link_marker=True):
+        range_calls.append((doc_id, name, start, end))
+        return "nr1"
+
+    def fake_create(service, file_id, content, quote, ref):
+        create_calls.append((file_id, content, quote, ref))
         return {"id": "c1"}
 
     def fake_reply(service, file_id, comment_id, content):
         reply_calls.append((file_id, comment_id, content))
 
+    monkeypatch.setattr("src.review.create_named_range", fake_range)
     monkeypatch.setattr("src.review.create_comment", fake_create)
     monkeypatch.setattr("src.review.reply_to_comment", fake_reply)
     monkeypatch.setattr(
@@ -215,23 +221,29 @@ def test_post_comments_calls_create(monkeypatch):
             "end_index": 3,
         }
     ]
-    post_comments("drive", "doc1", items)
-    expected_region = {"segment": {"startIndex": 1, "endIndex": 3}}
-    assert create_calls == [("doc1", "Fix typo", "head", [expected_region])]
+    post_comments("drive", "docs", "doc1", items)
+    assert range_calls == [("doc1", "abcd", 1, 3)]
+    assert create_calls == [("doc1", "Fix typo", "teh", "nr1")]
     assert reply_calls == []
 
 
-def test_post_comments_splits_long_comments(monkeypatch, region):
+def test_post_comments_splits_long_comments(monkeypatch):
     create_calls = []
     reply_calls = []
+    range_calls = []
 
-    def fake_create(service, file_id, content, revision_id="head", regions=None):
-        create_calls.append((file_id, content, revision_id, regions))
+    def fake_range(service, doc_id, name, start, end, link_marker=True):
+        range_calls.append((doc_id, name, start, end))
+        return "nr1"
+
+    def fake_create(service, file_id, content, quote, ref):
+        create_calls.append((file_id, content, quote, ref))
         return {"id": "c1"}
 
     def fake_reply(service, file_id, comment_id, content):
         reply_calls.append((file_id, comment_id, content))
 
+    monkeypatch.setattr("src.review.create_named_range", fake_range)
     monkeypatch.setattr("src.review.create_comment", fake_create)
     monkeypatch.setattr("src.review.reply_to_comment", fake_reply)
     monkeypatch.setattr(
@@ -248,7 +260,7 @@ def test_post_comments_splits_long_comments(monkeypatch, region):
             "end_index": 1,
         }
     ]
-    post_comments("drive", "doc1", items)
+    post_comments("drive", "docs", "doc1", items)
 
     # First chunk is posted as the main comment, remaining as replies
     assert len(create_calls) == 1
@@ -256,7 +268,7 @@ def test_post_comments_splits_long_comments(monkeypatch, region):
     # Ensure the created comment respects size limit
     assert len(create_calls[0][1].encode("utf-8")) <= 4096
     assert len(reply_calls[0][2].encode("utf-8")) <= 4096
-    assert create_calls[0][3] == [region]
+    assert create_calls[0][3] == "nr1"
 
 
 def test_suggestion_hashes_property_total_size_limit():

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -28,7 +28,7 @@ def test_run_once_reviews_and_posts(monkeypatch, tmp_path):
 
     posted = []
 
-    def fake_post(drive_service, doc_id, items):
+    def fake_post(drive_service, docs_service, doc_id, items):
         posted.append((doc_id, items))
 
     monkeypatch.setattr("src.main.post_comments", fake_post)
@@ -59,7 +59,7 @@ def test_process_document_success(monkeypatch):
 
     posted: list[tuple[str, list[dict[str, str]]]] = []
 
-    def fake_post(drive_service, doc_id, items):
+    def fake_post(drive_service, docs_service, doc_id, items):
         posted.append((doc_id, items))
 
     monkeypatch.setattr("src.main.post_comments", fake_post)


### PR DESCRIPTION
## Summary
- support creating Docs named ranges and optional "🔗" jump markers
- reference named ranges in Drive comments instead of anchors
- update review pipeline to create ranges and pass them to comments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8012515f88328b441c81fbe921ebf